### PR TITLE
feat(programs): multi-week progression plans (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to LiftTrace are documented here.
 
 ---
 
+## Unreleased
+
+### Added
+
+- **Multi-Week Progression Plans.** Programs can now span a training block of multiple weeks, with a per-week Sets / Reps / Tempo / Rest / Load matrix instead of one flat prescription. Set a program's **Duration (weeks)** and the Workout editor gains a Week tab strip (with a "copy this week → next" shortcut) plus new **Tempo** and **Rest (s)** fields. The Diary resolves which week you're on — by default advancing as you log sessions (calendar mode optional) — and prefills that week's targets when you load the workout; inside a programmed block the plan's prescription wins over last-session auto-fill. A per-exercise **Rest** feeds the rest timer. Repeat or regress a week from the Load Workout sheet, and choose whether the plan holds on the final week or repeats. Existing single-week programs are unchanged.
+
 ## v1.0.0 — 2026-07-18
 
 First stable release under the new semver scheme. Delivers Garmin FIT strength imports, per-set template parity between the Program editor and Diary set rows, a real Send Test email flow, multi-tag Docker publishing, and a high-severity `adm-zip` CVE patch in the backup restore path.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -14,6 +14,68 @@ The app will be available at `http://localhost:3002`.
 
 ---
 
+## Local Development
+
+Two ways to run the app from a source checkout. **Pick the single-origin
+path when you need to verify your own branch end-to-end** — the Vite dev
+server has a well-known blank-screen pitfall (below) and, being a separate
+origin, exercises a different request path than production.
+
+> Docker (`docker compose up -d`) pulls the published
+> `ghcr.io/traceapps/lifttrace:latest` image — it does **not** contain your
+> local changes. To test a branch you must run one of the paths below (or
+> `docker build` a local image from the `Dockerfile`).
+
+### Path A — Vite dev server (hot reload, day-to-day frontend work)
+
+```bash
+cd server && node index.js   # API on :3003
+npm run dev                  # Vite on :5173, proxies /api → :3003
+```
+
+Fast HMR, but it runs the frontend on a **separate origin** (`:5173`) from
+the API (`:3003`) via a proxy. This is convenient for iterating on markup
+but is the source of the recurring **blank-page-with-only-the-nav-bar**
+symptom (see below).
+
+### Path B — Single origin (recommended for verifying a branch)
+
+The Express server serves the built frontend from `server/dist` (this is
+exactly what the production image does — see `Dockerfile`). Building and
+serving it yourself gives you one origin, no proxy, and the same code path
+users hit:
+
+```bash
+npm run build                # → dist/  (Vite output)
+rm -rf server/dist && cp -r dist server/dist
+cd server && node index.js   # app + API together on :3003
+```
+
+Open `http://localhost:3003`. Re-run the three lines after any **frontend**
+change — the server pre-templates `dist/index.html` at startup, so a rebuild
+needs a server restart to be picked up. Backend-only changes just need the
+server restarted (or use `npm run dev` in `server/` for `--watch`).
+
+### Troubleshooting: blank page (nav/shell renders, content area empty)
+
+Almost always a **dev-only artifact of the Vite split setup (Path A)**, not a
+code bug — the two usual causes:
+
+1. **Stale PWA service worker.** LiftTrace registers a service worker; a
+   worker cached from an earlier session keeps serving a stale app shell
+   while the real route content fails to load. Fix: DevTools → **Application**
+   → **Service Workers** → **Unregister**, then **Storage** → **Clear site
+   data**, then hard-reload (`Cmd/Ctrl+Shift+R`).
+2. **Cross-origin proxy gap.** `GET /` requests landing on `:3003` (the API
+   port, which has no frontend in Path A) or a stalled auth probe leave the
+   shell mounted with no data.
+
+If clearing the service worker doesn't fix it, **switch to Path B** — serving
+from a single origin sidesteps both causes entirely and is the reliable way
+to confirm whether a blank screen is your code or just the dev setup.
+
+---
+
 ## Image tags
 
 Every release publishes a multi-arch (linux/amd64 + linux/arm64) image

--- a/server/db.js
+++ b/server/db.js
@@ -288,9 +288,12 @@ addColumnIfMissing('programs', 'on_complete', "on_complete TEXT DEFAULT 'hold'")
 // Manual week override so an athlete can repeat/regress a week. NULL = auto.
 // week_cursor_session_base captures sessions_in_program at the moment the
 // cursor was pinned, so auto-advance resumes *relative to* the pin rather
-// than freezing on it.
+// than freezing on it. week_cursor_pinned_at is the calendar-mode analogue:
+// the timestamp the cursor was pinned, so calendar-mode programs advance by
+// days-since-pin instead of freezing on the pinned week.
 addColumnIfMissing('program_assignments', 'week_cursor', 'week_cursor INTEGER');
 addColumnIfMissing('program_assignments', 'week_cursor_session_base', 'week_cursor_session_base INTEGER');
+addColumnIfMissing('program_assignments', 'week_cursor_pinned_at', 'week_cursor_pinned_at TEXT');
 // The plan week a logged session was performed in, stamped when the workout
 // is loaded from a multi-week program. NULL for non-programmed workouts.
 // Persisted (not derived) so a past session keeps its week after the athlete

--- a/server/db.js
+++ b/server/db.js
@@ -272,6 +272,31 @@ function addColumnIfMissing(table, column, ddl) {
 // Phase 1 — trainer-member relationship. Nullable FK on users.
 addColumnIfMissing('users', 'trainer_id', 'trainer_id INTEGER REFERENCES users(id) ON DELETE SET NULL');
 
+// Multi-week progression plans (issue #13). All additive — a program with
+// duration_weeks = 1 (the default) reproduces the old flat-prescription
+// behaviour, so existing programs and templates are untouched. The per-week
+// matrix itself lives inside the templates' `exercises` JSON (optional
+// `weeks[]` / `tempo` / `rest_sec` keys), which needs no schema change.
+addColumnIfMissing('programs', 'duration_weeks', 'duration_weeks INTEGER DEFAULT 1');
+// How the athlete's current plan week advances: 'sessions' (default —
+// advance once the week's prescribed number of program sessions is logged)
+// or 'calendar' (floor(days/7)+1 from start).
+addColumnIfMissing('programs', 'advance_mode', "advance_mode TEXT DEFAULT 'sessions'");
+// Behaviour past the final week: 'hold' (default — stay on the last week) or
+// 'repeat' (loop back to week 1 for repeating blocks).
+addColumnIfMissing('programs', 'on_complete', "on_complete TEXT DEFAULT 'hold'");
+// Manual week override so an athlete can repeat/regress a week. NULL = auto.
+// week_cursor_session_base captures sessions_in_program at the moment the
+// cursor was pinned, so auto-advance resumes *relative to* the pin rather
+// than freezing on it.
+addColumnIfMissing('program_assignments', 'week_cursor', 'week_cursor INTEGER');
+addColumnIfMissing('program_assignments', 'week_cursor_session_base', 'week_cursor_session_base INTEGER');
+// The plan week a logged session was performed in, stamped when the workout
+// is loaded from a multi-week program. NULL for non-programmed workouts.
+// Persisted (not derived) so a past session keeps its week after the athlete
+// advances — a logged Week 2 always reads Week 2.
+addColumnIfMissing('workout_log', 'program_week', 'program_week INTEGER');
+
 // Phase 2 — trainer prescribes workouts to members (undated "try this" or
 // dated "do this on YYYY-MM-DD"). Either template_id references a template,
 // or name+exercises hold an inline ad-hoc workout. date NULL = undated.

--- a/server/lib/programWeek.js
+++ b/server/lib/programWeek.js
@@ -1,0 +1,52 @@
+/**
+ * programWeek.js — resolve an athlete's current plan week for a multi-week
+ * progression program (issue #13).
+ *
+ * A program has `duration_weeks` (default 1 = non-progressed), an
+ * `advance_mode` ('sessions' | 'calendar') and an `on_complete` policy
+ * ('hold' | 'repeat'). The assignment may carry a manual `week_cursor`
+ * (with `week_cursor_session_base`) so the athlete can repeat/regress a week.
+ *
+ * Used by routes/programs.js now; importable by AI/coaching context later.
+ */
+
+/**
+ * @param {object} program    - programs row (duration_weeks, advance_mode, on_complete)
+ * @param {object} assignment - program_assignments row (start_date, assigned_at,
+ *                               week_cursor, week_cursor_session_base) — may be null
+ * @param {object} opts
+ * @param {number} opts.sessionsInProgram - completed program-attributed sessions
+ * @param {number} opts.sessionsPerWeek   - workouts that make up one plan week
+ * @returns {number} current plan week, 1-based
+ */
+export function currentPlanWeek(program, assignment, { sessionsInProgram = 0, sessionsPerWeek = 1 } = {}) {
+  const duration = Math.max(1, program?.duration_weeks || 1);
+  const perWeek = Math.max(1, sessionsPerWeek || 1);
+  const mode = program?.advance_mode || 'sessions';
+
+  let week;
+  const cursor = assignment?.week_cursor;
+  if (cursor != null) {
+    // Manual pin: current week starts at the cursor and auto-advances from
+    // the sessions logged *after* the pin, so repeating a week doesn't strand
+    // the athlete there forever.
+    const base = assignment?.week_cursor_session_base || 0;
+    const since = Math.max(0, sessionsInProgram - base);
+    week = cursor + Math.floor(since / perWeek);
+  } else if (mode === 'calendar') {
+    const anchor = assignment?.start_date || assignment?.assigned_at;
+    const since = anchor ? new Date(anchor).getTime() : Date.now();
+    const days = Math.max(0, Math.floor((Date.now() - since) / 86400000));
+    week = Math.floor(days / 7) + 1;
+  } else {
+    // Default: advance by sessions completed.
+    week = Math.floor(sessionsInProgram / perWeek) + 1;
+  }
+
+  if (program?.on_complete === 'repeat') {
+    // Loop back to week 1 past the end. week is 1-based.
+    return ((week - 1) % duration + duration) % duration + 1;
+  }
+  // Hold on the final week (and never below week 1).
+  return Math.min(duration, Math.max(1, week));
+}

--- a/server/routes/full-backup.js
+++ b/server/routes/full-backup.js
@@ -13,6 +13,31 @@ import { seedAiFromEnv } from '../ai.js';
 const router = express.Router();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Multi-week progression columns (issue #13) were added after the first
+// backup format. Older dumps predate them, so their rows lack the keys —
+// and better-sqlite3 throws on a missing named parameter. Fill defaults so
+// a legacy backup still restores, while a current backup round-trips the
+// real values.
+function _withField(row, key, fallback = null) {
+  return key in row ? row : { ...row, [key]: fallback };
+}
+function _withProgramDefaults(p) {
+  return {
+    ...p,
+    duration_weeks: p.duration_weeks ?? 1,
+    advance_mode:   p.advance_mode   ?? 'sessions',
+    on_complete:    p.on_complete    ?? 'hold',
+  };
+}
+function _withAssignDefaults(a) {
+  return {
+    ...a,
+    week_cursor:              a.week_cursor              ?? null,
+    week_cursor_session_base: a.week_cursor_session_base ?? null,
+    week_cursor_pinned_at:    a.week_cursor_pinned_at    ?? null,
+  };
+}
+
 const UPLOADS_DIR = process.env.UPLOADS_PATH || path.resolve(__dirname, '..', 'uploads');
 const BACKUPS_DIR = process.env.BACKUPS_PATH || path.join(UPLOADS_DIR, 'backups');
 fs.mkdirSync(BACKUPS_DIR, { recursive: true });
@@ -212,20 +237,20 @@ function restoreFromZip(zip) {
     const insExercise = db.prepare(`INSERT OR IGNORE INTO exercises (id,name,category,primary_muscles,secondary_muscles,equipment,instructions,tips,img_url,gif_url,video_url,external_id,source,is_global,created_by,created_at) VALUES (@id,@name,@category,@primary_muscles,@secondary_muscles,@equipment,@instructions,@tips,@img_url,@gif_url,@video_url,@external_id,@source,@is_global,@created_by,@created_at)`);
     for (const e of data.exercises || []) insExercise.run(e);
 
-    const insProgram = db.prepare(`INSERT OR IGNORE INTO programs (id,name,description,goal,created_by,visibility,created_at) VALUES (@id,@name,@description,@goal,@created_by,@visibility,@created_at)`);
-    for (const p of data.programs || []) insProgram.run(p);
+    const insProgram = db.prepare(`INSERT OR IGNORE INTO programs (id,name,description,goal,created_by,visibility,created_at,duration_weeks,advance_mode,on_complete) VALUES (@id,@name,@description,@goal,@created_by,@visibility,@created_at,@duration_weeks,@advance_mode,@on_complete)`);
+    for (const p of data.programs || []) insProgram.run(_withProgramDefaults(p));
 
     const insTemplate = db.prepare(`INSERT OR IGNORE INTO workout_templates (id,program_id,name,day_label,order_index,exercises,created_at) VALUES (@id,@program_id,@name,@day_label,@order_index,@exercises,@created_at)`);
     for (const t of data.workout_templates || []) insTemplate.run(t);
 
-    const insAssign = db.prepare(`INSERT OR IGNORE INTO program_assignments (id,program_id,assigned_to,assigned_by,start_date,active,assigned_at) VALUES (@id,@program_id,@assigned_to,@assigned_by,@start_date,@active,@assigned_at)`);
-    for (const a of data.program_assignments || []) insAssign.run(a);
+    const insAssign = db.prepare(`INSERT OR IGNORE INTO program_assignments (id,program_id,assigned_to,assigned_by,start_date,active,assigned_at,week_cursor,week_cursor_session_base,week_cursor_pinned_at) VALUES (@id,@program_id,@assigned_to,@assigned_by,@start_date,@active,@assigned_at,@week_cursor,@week_cursor_session_base,@week_cursor_pinned_at)`);
+    for (const a of data.program_assignments || []) insAssign.run(_withAssignDefaults(a));
 
     const insPrescription = db.prepare(`INSERT OR IGNORE INTO coach_prescriptions (id,trainer_id,member_id,date,template_id,name,exercises,notes,created_at) VALUES (@id,@trainer_id,@member_id,@date,@template_id,@name,@exercises,@notes,@created_at)`);
     for (const cp of data.coach_prescriptions || []) insPrescription.run(cp);
 
-    const insWorkout = db.prepare(`INSERT OR IGNORE INTO workout_log (id,user_id,date,template_id,program_id,name,exercises,notes,duration_min,completed,created_at) VALUES (@id,@user_id,@date,@template_id,@program_id,@name,@exercises,@notes,@duration_min,@completed,@created_at)`);
-    for (const w of data.workout_log || []) insWorkout.run(w);
+    const insWorkout = db.prepare(`INSERT OR IGNORE INTO workout_log (id,user_id,date,template_id,program_id,name,exercises,notes,duration_min,completed,created_at,program_week) VALUES (@id,@user_id,@date,@template_id,@program_id,@name,@exercises,@notes,@duration_min,@completed,@created_at,@program_week)`);
+    for (const w of data.workout_log || []) insWorkout.run(_withField(w, 'program_week'));
 
     const insBody = db.prepare(`INSERT OR IGNORE INTO body_stats_log (id,user_id,date,stats) VALUES (@id,@user_id,@date,@stats)`);
     for (const b of data.body_stats_log || []) insBody.run(b);

--- a/server/routes/programs.js
+++ b/server/routes/programs.js
@@ -53,7 +53,7 @@ router.get('/', wrap((req, res) => {
 
     if (p.is_active && userId != null) {
       const assigned = db.prepare(
-        `SELECT assigned_at, start_date, week_cursor, week_cursor_session_base
+        `SELECT assigned_at, start_date, week_cursor, week_cursor_session_base, week_cursor_pinned_at
            FROM program_assignments
           WHERE program_id = ? AND assigned_to = ? AND active = 1`
       ).get(p.id, userId);
@@ -81,6 +81,16 @@ router.get('/', wrap((req, res) => {
         sessionsInProgram: p.sessions_in_program,
         sessionsPerWeek: p.template_count,
       });
+    } else if (p.is_active && userId == null) {
+      // Single-user mode has no program_assignments row — the active flag and
+      // the manual week cursor both live in app_config. Resolve current_week
+      // here too so the list card matches the detail view + Load-Workout sheet.
+      const cursor = readSoloCursor();
+      p.sessions_in_program = sessionsInProgram(null, p.id, null);
+      p.current_week = currentPlanWeek(p, cursor, {
+        sessionsInProgram: p.sessions_in_program,
+        sessionsPerWeek: p.template_count,
+      });
     }
   }
   res.json(programs);
@@ -100,7 +110,7 @@ router.get('/:id', wrap((req, res) => {
   let assignment = null;
   if (userId != null) {
     assignment = db.prepare(
-      `SELECT active, assigned_at, start_date, week_cursor, week_cursor_session_base
+      `SELECT active, assigned_at, start_date, week_cursor, week_cursor_session_base, week_cursor_pinned_at
          FROM program_assignments WHERE program_id = ? AND assigned_to = ?`
     ).get(id, userId);
     program.is_active = assignment?.active === 1;
@@ -144,8 +154,12 @@ function readSoloCursor() {
   const row = db.prepare("SELECT value FROM app_config WHERE key = 'active_program_cursor'").get();
   if (!row?.value) return {};
   try {
-    const { week, base } = JSON.parse(row.value);
-    return { week_cursor: week ?? null, week_cursor_session_base: base ?? 0 };
+    const { week, base, pinnedAt } = JSON.parse(row.value);
+    return {
+      week_cursor: week ?? null,
+      week_cursor_session_base: base ?? 0,
+      week_cursor_pinned_at: pinnedAt ?? null,
+    };
   } catch { return {}; }
 }
 
@@ -254,10 +268,11 @@ router.post('/:id/week-cursor', wrap((req, res) => {
     ).get(id, userId);
     if (!assigned) return res.status(400).json({ error: 'Program is not active for this user' });
     const base = week != null ? sessionsInProgram(userId, id, assigned.assigned_at) : null;
+    const pinnedAt = week != null ? new Date().toISOString() : null;
     db.prepare(
-      `UPDATE program_assignments SET week_cursor = ?, week_cursor_session_base = ?
+      `UPDATE program_assignments SET week_cursor = ?, week_cursor_session_base = ?, week_cursor_pinned_at = ?
         WHERE program_id = ? AND assigned_to = ?`
-    ).run(week ?? null, base, id, userId);
+    ).run(week ?? null, base, pinnedAt, id, userId);
   } else {
     if (week == null) {
       db.prepare("DELETE FROM app_config WHERE key = 'active_program_cursor'").run();
@@ -265,7 +280,7 @@ router.post('/:id/week-cursor', wrap((req, res) => {
       const base = sessionsInProgram(null, id, null);
       db.prepare(
         "INSERT INTO app_config (key, value) VALUES ('active_program_cursor', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
-      ).run(JSON.stringify({ week, base }));
+      ).run(JSON.stringify({ week, base, pinnedAt: new Date().toISOString() }));
     }
   }
   res.json({ ok: true, week: week ?? null });

--- a/server/routes/programs.js
+++ b/server/routes/programs.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import db from '../db.js';
 import { wrap } from '../logger.js';
 import { requireAuth, requireTrainerOrAdmin, uid, userMgmtActive } from '../middleware/auth.js';
+import { currentPlanWeek } from '../lib/programWeek.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -52,7 +53,8 @@ router.get('/', wrap((req, res) => {
 
     if (p.is_active && userId != null) {
       const assigned = db.prepare(
-        `SELECT assigned_at FROM program_assignments
+        `SELECT assigned_at, start_date, week_cursor, week_cursor_session_base
+           FROM program_assignments
           WHERE program_id = ? AND assigned_to = ? AND active = 1`
       ).get(p.id, userId);
       if (assigned?.assigned_at) {
@@ -74,6 +76,11 @@ router.get('/', wrap((req, res) => {
             AND wl.template_id IN (SELECT id FROM workout_templates WHERE program_id = ?)
             ${sinceFilter}
       `).get(...args)?.c || 0;
+      // Multi-week progression: resolve which plan week the athlete is on.
+      p.current_week = currentPlanWeek(p, assigned, {
+        sessionsInProgram: p.sessions_in_program,
+        sessionsPerWeek: p.template_count,
+      });
     }
   }
   res.json(programs);
@@ -88,35 +95,100 @@ router.get('/:id', wrap((req, res) => {
   for (const t of templates) t.exercises = JSON.parse(t.exercises || '[]');
   program.templates = templates;
 
-  // Check if active
+  // Check if active + resolve the current plan week for the caller.
   const userId = uid(req);
+  let assignment = null;
   if (userId != null) {
-    const pa = db.prepare('SELECT active FROM program_assignments WHERE program_id = ? AND assigned_to = ?').get(id, userId);
-    program.is_active = pa?.active === 1;
+    assignment = db.prepare(
+      `SELECT active, assigned_at, start_date, week_cursor, week_cursor_session_base
+         FROM program_assignments WHERE program_id = ? AND assigned_to = ?`
+    ).get(id, userId);
+    program.is_active = assignment?.active === 1;
   } else {
     const active = db.prepare("SELECT value FROM app_config WHERE key = 'active_program'").get();
     program.is_active = active && parseInt(active.value) === id;
+    if (program.is_active) assignment = readSoloCursor();
+  }
+
+  if (program.is_active) {
+    const sessions = sessionsInProgram(userId, id, assignment?.assigned_at);
+    program.sessions_in_program = sessions;
+    program.current_week = currentPlanWeek(program, assignment, {
+      sessionsInProgram: sessions,
+      sessionsPerWeek: templates.length,
+    });
   }
   res.json(program);
 }));
 
+// Completed program-attributed sessions since assignment. userId null =
+// single-user mode (no user_id filter needed).
+function sessionsInProgram(userId, programId, assignedAt) {
+  const sinceFilter = assignedAt ? "AND date >= date(?)" : "";
+  const userFilter = userId != null ? "wl.user_id = ? AND" : "";
+  const args = [];
+  if (userId != null) args.push(userId);
+  args.push(programId);
+  if (assignedAt) args.push(assignedAt);
+  return db.prepare(`
+    SELECT COUNT(*) as c FROM workout_log wl
+      WHERE ${userFilter} wl.completed = 1
+        AND wl.template_id IN (SELECT id FROM workout_templates WHERE program_id = ?)
+        ${sinceFilter}
+  `).get(...args)?.c || 0;
+}
+
+// Single-user (no-auth) mode has no program_assignments row, so the manual
+// week cursor lives in app_config as JSON alongside the active_program key.
+function readSoloCursor() {
+  const row = db.prepare("SELECT value FROM app_config WHERE key = 'active_program_cursor'").get();
+  if (!row?.value) return {};
+  try {
+    const { week, base } = JSON.parse(row.value);
+    return { week_cursor: week ?? null, week_cursor_session_base: base ?? 0 };
+  } catch { return {}; }
+}
+
 // POST /api/programs
 router.post('/', wrap((req, res) => {
-  const { name, description, goal, visibility } = req.body;
+  const { name, description, goal, visibility, duration_weeks, advance_mode, on_complete } = req.body;
   if (!name) return res.status(400).json({ error: 'Name required' });
-  const result = db.prepare('INSERT INTO programs (name, description, goal, created_by, visibility) VALUES (?, ?, ?, ?, ?)')
-    .run(name, description || null, goal || 'general', uid(req), visibility || 'private');
+  const result = db.prepare(
+    `INSERT INTO programs (name, description, goal, created_by, visibility, duration_weeks, advance_mode, on_complete)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    name, description || null, goal || 'general', uid(req), visibility || 'private',
+    clampDuration(duration_weeks), advanceMode(advance_mode), onComplete(on_complete)
+  );
   res.json(db.prepare('SELECT * FROM programs WHERE id = ?').get(result.lastInsertRowid));
 }));
 
 // PUT /api/programs/:id
 router.put('/:id', wrap((req, res) => {
   const id = parseInt(req.params.id);
-  const { name, description, goal, visibility } = req.body;
-  db.prepare('UPDATE programs SET name=COALESCE(?,name), description=COALESCE(?,description), goal=COALESCE(?,goal), visibility=COALESCE(?,visibility) WHERE id=?')
-    .run(name || null, description, goal || null, visibility || null, id);
+  const { name, description, goal, visibility, duration_weeks, advance_mode, on_complete } = req.body;
+  db.prepare(
+    `UPDATE programs SET name=COALESCE(?,name), description=COALESCE(?,description),
+            goal=COALESCE(?,goal), visibility=COALESCE(?,visibility),
+            duration_weeks=COALESCE(?,duration_weeks), advance_mode=COALESCE(?,advance_mode),
+            on_complete=COALESCE(?,on_complete) WHERE id=?`
+  ).run(
+    name || null, description, goal || null, visibility || null,
+    duration_weeks != null ? clampDuration(duration_weeks) : null,
+    advance_mode != null ? advanceMode(advance_mode) : null,
+    on_complete != null ? onComplete(on_complete) : null,
+    id
+  );
   res.json(db.prepare('SELECT * FROM programs WHERE id = ?').get(id));
 }));
+
+// Sanitise the progression fields so bad input can't corrupt week resolution.
+function clampDuration(v) {
+  const n = parseInt(v);
+  return Number.isFinite(n) ? Math.min(52, Math.max(1, n)) : 1;
+}
+function advanceMode(v) { return v === 'calendar' ? 'calendar' : 'sessions'; }
+function onComplete(v) { return v === 'repeat' ? 'repeat' : 'hold'; }
 
 // DELETE /api/programs/:id
 router.delete('/:id', wrap((req, res) => {
@@ -131,6 +203,7 @@ router.post('/deactivate', wrap((req, res) => {
     db.prepare('UPDATE program_assignments SET active = 0 WHERE assigned_to = ?').run(userId);
   } else {
     db.prepare("DELETE FROM app_config WHERE key = 'active_program'").run();
+    db.prepare("DELETE FROM app_config WHERE key = 'active_program_cursor'").run();
   }
   res.json({ ok: true });
 }));
@@ -152,8 +225,50 @@ router.post('/:id/activate', wrap((req, res) => {
   } else {
     db.prepare("INSERT INTO app_config (key, value) VALUES ('active_program', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
       .run(String(id));
+    // Switching the solo active program invalidates any pinned week cursor.
+    db.prepare("DELETE FROM app_config WHERE key = 'active_program_cursor'").run();
   }
   res.json({ ok: true });
+}));
+
+// POST /api/programs/:id/week-cursor — manually pin the current plan week so
+// the athlete can repeat or regress a week. { week: null } clears the pin and
+// returns to auto-advance. Captures the current session count as the baseline
+// so auto-advance resumes relative to the pin (see lib/programWeek.js).
+router.post('/:id/week-cursor', wrap((req, res) => {
+  const id = parseInt(req.params.id);
+  const userId = uid(req);
+  const program = db.prepare('SELECT * FROM programs WHERE id = ?').get(id);
+  if (!program) return res.status(404).json({ error: 'Program not found' });
+
+  let week = req.body?.week;
+  if (week != null) {
+    week = parseInt(week);
+    if (!Number.isFinite(week)) return res.status(400).json({ error: 'week must be a number or null' });
+    week = Math.min(Math.max(1, program.duration_weeks || 1), Math.max(1, week));
+  }
+
+  if (userId != null) {
+    const assigned = db.prepare(
+      'SELECT assigned_at FROM program_assignments WHERE program_id = ? AND assigned_to = ? AND active = 1'
+    ).get(id, userId);
+    if (!assigned) return res.status(400).json({ error: 'Program is not active for this user' });
+    const base = week != null ? sessionsInProgram(userId, id, assigned.assigned_at) : null;
+    db.prepare(
+      `UPDATE program_assignments SET week_cursor = ?, week_cursor_session_base = ?
+        WHERE program_id = ? AND assigned_to = ?`
+    ).run(week ?? null, base, id, userId);
+  } else {
+    if (week == null) {
+      db.prepare("DELETE FROM app_config WHERE key = 'active_program_cursor'").run();
+    } else {
+      const base = sessionsInProgram(null, id, null);
+      db.prepare(
+        "INSERT INTO app_config (key, value) VALUES ('active_program_cursor', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+      ).run(JSON.stringify({ week, base }));
+    }
+  }
+  res.json({ ok: true, week: week ?? null });
 }));
 
 // POST /api/programs/:id/assign — trainer/admin assigns program to user.

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -286,16 +286,16 @@ router.post('/push', wrap((req, res) => {
             db.prepare(`UPDATE workout_log SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(existing.id);
           } else {
             db.prepare(
-              `UPDATE workout_log SET name=?, exercises=?, notes=?, duration_min=?, completed=?, template_id=?, program_id=?, updated_at=datetime('now') WHERE id=?`
-            ).run(w.name || null, JSON.stringify(w.exercises || []), w.notes || null, w.duration_min ?? null, w.completed ? 1 : 0, w.template_id || null, w.program_id || null, existing.id);
+              `UPDATE workout_log SET name=?, exercises=?, notes=?, duration_min=?, completed=?, template_id=?, program_id=?, program_week=?, updated_at=datetime('now') WHERE id=?`
+            ).run(w.name || null, JSON.stringify(w.exercises || []), w.notes || null, w.duration_min ?? null, w.completed ? 1 : 0, w.template_id || null, w.program_id || null, w.program_week ?? null, existing.id);
           }
         }
         result.workout_log.push({ client_id: w.client_id, server_id: existing.id });
       } else if (!w.deleted_at) {
         const r = db.prepare(
-          `INSERT INTO workout_log (user_id, date, name, exercises, notes, duration_min, completed, template_id, program_id, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
-        ).run(u, w.date, w.name || null, JSON.stringify(w.exercises || []), w.notes || null, w.duration_min ?? null, w.completed ? 1 : 0, w.template_id || null, w.program_id || null);
+          `INSERT INTO workout_log (user_id, date, name, exercises, notes, duration_min, completed, template_id, program_id, program_week, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+        ).run(u, w.date, w.name || null, JSON.stringify(w.exercises || []), w.notes || null, w.duration_min ?? null, w.completed ? 1 : 0, w.template_id || null, w.program_id || null, w.program_week ?? null);
         result.workout_log.push({ client_id: w.client_id, server_id: r.lastInsertRowid });
       }
     }

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -236,16 +236,16 @@ router.post('/push', wrap((req, res) => {
             db.prepare(`UPDATE programs SET deleted_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`).run(p.server_id);
           } else {
             db.prepare(
-              `UPDATE programs SET name=?, description=?, goal=?, visibility=?, updated_at=datetime('now') WHERE id=?`
-            ).run(p.name, p.description || null, p.goal || 'general', p.visibility || 'private', p.server_id);
+              `UPDATE programs SET name=?, description=?, goal=?, visibility=?, duration_weeks=?, advance_mode=?, on_complete=?, updated_at=datetime('now') WHERE id=?`
+            ).run(p.name, p.description || null, p.goal || 'general', p.visibility || 'private', p.duration_weeks ?? 1, p.advance_mode || 'sessions', p.on_complete || 'hold', p.server_id);
           }
         }
         result.programs.push({ client_id: p.client_id, server_id: p.server_id });
       } else if (!p.deleted_at) {
         const r = db.prepare(
-          `INSERT INTO programs (name, description, goal, visibility, created_by, updated_at)
-           VALUES (?, ?, ?, ?, ?, datetime('now'))`
-        ).run(p.name, p.description || null, p.goal || 'general', p.visibility || 'private', u);
+          `INSERT INTO programs (name, description, goal, visibility, duration_weeks, advance_mode, on_complete, created_by, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+        ).run(p.name, p.description || null, p.goal || 'general', p.visibility || 'private', p.duration_weeks ?? 1, p.advance_mode || 'sessions', p.on_complete || 'hold', u);
         result.programs.push({ client_id: p.client_id, server_id: r.lastInsertRowid });
       }
     }

--- a/server/routes/templates.js
+++ b/server/routes/templates.js
@@ -8,7 +8,15 @@ router.use(requireAuth);
 
 // GET /api/templates/:id
 router.get('/:id', wrap((req, res) => {
-  const t = db.prepare('SELECT * FROM workout_templates WHERE id = ?').get(parseInt(req.params.id));
+  // Join the parent program's duration_weeks so the editor knows how many
+  // week tabs to render for the per-week progression matrix (issue #13)
+  // without a second round-trip.
+  const t = db.prepare(
+    `SELECT wt.*, p.duration_weeks
+       FROM workout_templates wt
+       JOIN programs p ON p.id = wt.program_id
+      WHERE wt.id = ?`
+  ).get(parseInt(req.params.id));
   if (!t) return res.status(404).json({ error: 'Template not found' });
   t.exercises = JSON.parse(t.exercises || '[]');
   res.json(t);

--- a/server/routes/workout.js
+++ b/server/routes/workout.js
@@ -80,6 +80,12 @@ router.get('/:date', wrap((req, res) => {
 
   if (workout) {
     workout.exercises = JSON.parse(workout.exercises || '[]');
+    // Surface the program's plan length alongside the stamped program_week so
+    // the diary can render "Week N of M" without a second request.
+    if (workout.program_id) {
+      workout.program_duration_weeks =
+        db.prepare('SELECT duration_weeks FROM programs WHERE id = ?').get(workout.program_id)?.duration_weeks ?? null;
+    }
     // Include any coach feedback left on this workout so the member's diary
     // can render it inline (workout-level banner + per-exercise notes).
     workout.feedback = db.prepare(`
@@ -98,7 +104,7 @@ router.get('/:date', wrap((req, res) => {
 router.put('/:date', wrap((req, res) => {
   const { date } = req.params;
   const userId = uid(req);
-  const { template_id, program_id, name, exercises, notes, duration_min, completed } = req.body;
+  const { template_id, program_id, name, exercises, notes, duration_min, completed, program_week } = req.body;
 
   const existing = userId != null
     ? db.prepare('SELECT id FROM workout_log WHERE date = ? AND user_id = ?').get(date, userId)
@@ -120,14 +126,14 @@ router.put('/:date', wrap((req, res) => {
 
   if (existing) {
     db.prepare(
-      `UPDATE workout_log SET template_id=?, program_id=?, name=?, exercises=?, notes=?, duration_min=?, completed=?
+      `UPDATE workout_log SET template_id=?, program_id=?, name=?, exercises=?, notes=?, duration_min=?, completed=?, program_week=?
        WHERE id=?`
-    ).run(template_id || null, program_id || null, name || null, exercisesJson, notes || null, duration_min || null, completed ? 1 : 0, existing.id);
+    ).run(template_id || null, program_id || null, name || null, exercisesJson, notes || null, duration_min || null, completed ? 1 : 0, program_week ?? null, existing.id);
   } else if (exercises && exercises.length > 0) {
     db.prepare(
-      `INSERT INTO workout_log (user_id, date, template_id, program_id, name, exercises, notes, duration_min, completed)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(userId, date, template_id || null, program_id || null, name || null, exercisesJson, notes || null, duration_min || null, completed ? 1 : 0);
+      `INSERT INTO workout_log (user_id, date, template_id, program_id, name, exercises, notes, duration_min, completed, program_week)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(userId, date, template_id || null, program_id || null, name || null, exercisesJson, notes || null, duration_min || null, completed ? 1 : 0, program_week ?? null);
   } else {
     return res.json({ workout: null });
   }

--- a/src/lib/api-native.js
+++ b/src/lib/api-native.js
@@ -18,6 +18,7 @@ import {
   getSyncMeta,
   setSyncMeta,
 } from './db-native.js';
+import { currentPlanWeek } from './programWeek.js';
 
 const ME = 1; // single-user id in standalone mode
 
@@ -48,6 +49,51 @@ function _exerciseFromRow(r) {
 
 function _programFromRow(r) {
   return r ? { ...r, deleted_at: undefined, sync_state: undefined } : null;
+}
+
+// Sanitise the multi-week progression fields on write — mirror of the server's
+// clampDuration / advanceMode / onComplete in server/routes/programs.js so a
+// program created offline resolves weeks identically once synced.
+function _clampDuration(v) {
+  const n = parseInt(v);
+  return Number.isFinite(n) ? Math.min(52, Math.max(1, n)) : 1;
+}
+const _advanceMode = v => (v === 'calendar' ? 'calendar' : 'sessions');
+const _onComplete  = v => (v === 'repeat' ? 'repeat' : 'hold');
+
+// Completed program-attributed sessions for a program (single-user: user_id=1).
+// Mirrors server/routes/programs.js sessionsInProgram.
+async function _sessionsInProgram(programId, assignedAt) {
+  const sinceFilter = assignedAt ? 'AND date >= date(?)' : '';
+  const args = [ME, programId];
+  if (assignedAt) args.push(assignedAt);
+  const row = (await dbQuery(
+    `SELECT COUNT(*) AS c FROM workout_log wl
+       WHERE wl.user_id = ? AND wl.completed = 1
+         AND wl.template_id IN (SELECT id FROM workout_templates WHERE program_id = ?)
+         ${sinceFilter}`,
+    args
+  ))[0];
+  return row?.c || 0;
+}
+
+// Resolve current_week for an active program row + its assignment, so the
+// Diary's week bar and week-aware prefill work offline. Returns { current_week,
+// sessions_in_program } or null when the program isn't progressed/active.
+async function _resolveCurrentWeek(program, assignment) {
+  if (!program || (program.duration_weeks || 1) <= 1) return null;
+  const tplCount = (await dbQuery(
+    `SELECT COUNT(*) AS c FROM workout_templates WHERE program_id = ? AND deleted_at IS NULL`,
+    [program.id]
+  ))[0]?.c || 0;
+  const sessions = await _sessionsInProgram(program.id, assignment?.assigned_at);
+  return {
+    sessions_in_program: sessions,
+    current_week: currentPlanWeek(program, assignment, {
+      sessionsInProgram: sessions,
+      sessionsPerWeek: tplCount,
+    }),
+  };
 }
 
 function _templateFromRow(r) {
@@ -272,13 +318,26 @@ const Programs = {
         `SELECT COUNT(*) AS c FROM workout_templates WHERE program_id = ? AND deleted_at IS NULL`,
         [r.id]
       ))[0]?.c || 0;
-      out.push({
-        ..._programFromRow(r),
+      const prog = _programFromRow(r);
+      const entry = {
+        ...prog,
         is_active: r._active ? 1 : 0,
         is_assigned: 0,
         assigned_by_name: null,
         template_count: tplCount,
-      });
+      };
+      // Resolve the current plan week for the active progressed program so the
+      // list card can show "Week N" (matches the server's GET /api/programs).
+      if (entry.is_active) {
+        const assignment = (await dbQuery(
+          `SELECT assigned_at, start_date, week_cursor, week_cursor_session_base, week_cursor_pinned_at
+             FROM program_assignments WHERE program_id = ? AND assigned_to = ? AND active = 1`,
+          [r.id, ME]
+        ))[0];
+        const wk = await _resolveCurrentWeek(prog, assignment);
+        if (wk) Object.assign(entry, wk);
+      }
+      out.push(entry);
     }
     return out;
   },
@@ -290,17 +349,29 @@ const Programs = {
       `SELECT * FROM workout_templates WHERE program_id = ? AND deleted_at IS NULL ORDER BY order_index, id`,
       [id]
     );
-    const isActive = (await dbQuery(
-      `SELECT active FROM program_assignments WHERE program_id = ? AND assigned_to = ?`,
+    const assignment = (await dbQuery(
+      `SELECT active, assigned_at, start_date, week_cursor, week_cursor_session_base, week_cursor_pinned_at
+         FROM program_assignments WHERE program_id = ? AND assigned_to = ?`,
       [id, ME]
-    ))[0]?.active === 1;
-    return { ..._programFromRow(rows[0]), is_active: isActive, templates: tpls.map(_templateFromRow) };
+    ))[0];
+    const isActive = assignment?.active === 1;
+    const prog = _programFromRow(rows[0]);
+    const out = { ...prog, is_active: isActive, templates: tpls.map(_templateFromRow) };
+    if (isActive) {
+      const wk = await _resolveCurrentWeek(prog, assignment);
+      if (wk) Object.assign(out, wk);
+    }
+    return out;
   },
   async create(body) {
     const r = await dbRun(
-      `INSERT INTO programs (name, description, goal, created_by, visibility, created_at, updated_at, sync_state)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')`,
-      [body.name, body.description || null, body.goal || 'general', ME, body.visibility || 'private', _now(), _now()]
+      `INSERT INTO programs (name, description, goal, created_by, visibility, duration_weeks, advance_mode, on_complete, created_at, updated_at, sync_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')`,
+      [
+        body.name, body.description || null, body.goal || 'general', ME, body.visibility || 'private',
+        _clampDuration(body.duration_weeks), _advanceMode(body.advance_mode), _onComplete(body.on_complete),
+        _now(), _now(),
+      ]
     );
     return Programs.get(r.lastId);
   },
@@ -310,6 +381,10 @@ const Programs = {
     for (const c of ['name', 'description', 'goal', 'visibility']) {
       if (body[c] !== undefined) { sets.push(`${c} = ?`); args.push(body[c]); }
     }
+    // Multi-week progression fields — sanitised the same way the server does.
+    if (body.duration_weeks !== undefined) { sets.push(`duration_weeks = ?`); args.push(_clampDuration(body.duration_weeks)); }
+    if (body.advance_mode   !== undefined) { sets.push(`advance_mode = ?`);   args.push(_advanceMode(body.advance_mode)); }
+    if (body.on_complete    !== undefined) { sets.push(`on_complete = ?`);    args.push(_onComplete(body.on_complete)); }
     sets.push(`updated_at = ?`); args.push(_now());
     sets.push(`sync_state = 'pending'`);
     args.push(id);
@@ -335,6 +410,34 @@ const Programs = {
     await dbRun(`UPDATE program_assignments SET active = 0 WHERE assigned_to = ?`, [ME]);
     return { ok: true };
   },
+  // Manually pin the current plan week so the athlete can repeat/regress
+  // (issue #13). Mirrors the server's POST /:id/week-cursor: clamp to
+  // [1, duration], capture the session base + pin timestamp so auto-advance
+  // resumes relative to the pin. { week: null } clears the pin.
+  async setWeekCursor(id, body) {
+    const prog = (await dbQuery(`SELECT * FROM programs WHERE id = ? AND deleted_at IS NULL`, [id]))[0];
+    if (!prog) throw new _Unsupported('Program not found');
+    let week = body?.week;
+    if (week != null) {
+      week = parseInt(week);
+      if (!Number.isFinite(week)) throw new _Unsupported('week must be a number or null');
+      week = Math.min(Math.max(1, prog.duration_weeks || 1), Math.max(1, week));
+    }
+    const assigned = (await dbQuery(
+      `SELECT assigned_at FROM program_assignments WHERE program_id = ? AND assigned_to = ? AND active = 1`,
+      [id, ME]
+    ))[0];
+    if (!assigned) throw new _Unsupported('Program is not active');
+    const base = week != null ? await _sessionsInProgram(id, assigned.assigned_at) : null;
+    const pinnedAt = week != null ? _now() : null;
+    await dbRun(
+      `UPDATE program_assignments
+          SET week_cursor = ?, week_cursor_session_base = ?, week_cursor_pinned_at = ?, updated_at = ?
+        WHERE program_id = ? AND assigned_to = ?`,
+      [week ?? null, base, pinnedAt, _now(), id, ME]
+    );
+    return { ok: true, week: week ?? null };
+  },
   async reorder(id, body) {
     const order = Array.isArray(body?.order) ? body.order : [];
     for (let i = 0; i < order.length; i++) {
@@ -356,7 +459,15 @@ const Templates = {
     return rows.map(_templateFromRow);
   },
   async get(id) {
-    const rows = await dbQuery(`SELECT * FROM workout_templates WHERE id = ? AND deleted_at IS NULL`, [id]);
+    // Join the parent program's duration_weeks so the WorkoutEditor renders the
+    // right number of week tabs (matches the server's GET /api/templates/:id).
+    const rows = await dbQuery(
+      `SELECT wt.*, p.duration_weeks
+         FROM workout_templates wt
+         JOIN programs p ON p.id = wt.program_id
+        WHERE wt.id = ? AND wt.deleted_at IS NULL`,
+      [id]
+    );
     return _templateFromRow(rows[0]);
   },
   async create(body) {
@@ -400,7 +511,17 @@ const Workout = {
       `SELECT * FROM workout_log WHERE user_id = ? AND date = ? AND deleted_at IS NULL`,
       [ME, date]
     );
-    return _workoutFromRow(rows[0]) || null;
+    const w = _workoutFromRow(rows[0]);
+    if (!w) return null;
+    // Surface the program's plan length alongside the stamped program_week so
+    // the diary can render "Week N of M" (matches the server's GET /:date).
+    if (w.program_id) {
+      w.program_duration_weeks = (await dbQuery(
+        `SELECT duration_weeks FROM programs WHERE id = ?`,
+        [w.program_id]
+      ))[0]?.duration_weeks ?? null;
+    }
+    return w;
   },
   async upsert(date, body) {
     const exercises = body.exercises || [];
@@ -421,7 +542,7 @@ const Workout = {
       await dbRun(
         `UPDATE workout_log
             SET template_id = ?, program_id = ?, name = ?, exercises = ?,
-                notes = ?, duration_min = ?, completed = ?, updated_at = ?, sync_state = 'pending'
+                notes = ?, duration_min = ?, completed = ?, program_week = ?, updated_at = ?, sync_state = 'pending'
           WHERE user_id = ? AND date = ?`,
         [
           body.template_id ?? existing.template_id ?? null,
@@ -431,15 +552,16 @@ const Workout = {
           body.notes ?? existing.notes ?? null,
           body.duration_min ?? existing.duration_min ?? null,
           body.completed ? 1 : 0,
+          body.program_week ?? existing.program_week ?? null,
           _now(), ME, date,
         ]
       );
     } else {
       await dbRun(
         `INSERT INTO workout_log
-          (user_id, date, template_id, program_id, name, exercises, notes, duration_min, completed,
+          (user_id, date, template_id, program_id, name, exercises, notes, duration_min, completed, program_week,
            created_at, updated_at, sync_state)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')`,
         [
           ME, date,
           body.template_id ?? null,
@@ -449,6 +571,7 @@ const Workout = {
           body.notes ?? null,
           body.duration_min ?? null,
           body.completed ? 1 : 0,
+          body.program_week ?? null,
           _now(), _now(),
         ]
       );
@@ -977,8 +1100,9 @@ async function handle(method, path, body, query) {
     if (/^\d+$/.test(id) && m === 'GET')        return Programs.get(Number(id));
     if (/^\d+$/.test(id) && m === 'PUT')        return Programs.update(Number(id), body || {});
     if (/^\d+$/.test(id) && m === 'DELETE')     return Programs.del(Number(id));
-    if (/^\d+$/.test(id) && sub === 'activate' && m === 'POST') return Programs.activate(Number(id));
-    if (/^\d+$/.test(id) && sub === 'reorder'  && m === 'PUT')  return Programs.reorder(Number(id), body || {});
+    if (/^\d+$/.test(id) && sub === 'activate'    && m === 'POST') return Programs.activate(Number(id));
+    if (/^\d+$/.test(id) && sub === 'week-cursor' && m === 'POST') return Programs.setWeekCursor(Number(id), body || {});
+    if (/^\d+$/.test(id) && sub === 'reorder'     && m === 'PUT')  return Programs.reorder(Number(id), body || {});
     // /api/programs/:id/assign[/:userId] — POST (assign) or DELETE (unassign).
     // Standalone has no other user to assign to, so these are no-ops here.
     // In native+server mode the dispatcher hits the server first and only

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -46,6 +46,7 @@ export const LtApi = {
   unassignProgram: (programId, userId) => fetch(`/api/programs/${programId}/assign/${userId}`, { ...opts, method: 'DELETE' }).then(_json),
   setActiveProgram: (id) => fetch(`/api/programs/${id}/activate`, { ...opts, method: 'POST' }).then(_json),
   deactivateProgram: () => fetch('/api/programs/deactivate', { ...opts, method: 'POST' }).then(_json),
+  setProgramWeekCursor: (id, week) => fetch(`/api/programs/${id}/week-cursor`, { ...jsonOpts, method: 'POST', body: JSON.stringify({ week }) }).then(_json),
 
   // ── Workout Templates ──────────────────────────────────────────────────
   getTemplate: (id) => fetch(`/api/templates/${id}`, opts).then(_json),

--- a/src/lib/db-native.js
+++ b/src/lib/db-native.js
@@ -170,6 +170,9 @@ async function _createSchema(db) {
       goal        TEXT DEFAULT 'general',
       created_by  INTEGER,
       visibility  TEXT DEFAULT 'private',
+      duration_weeks INTEGER DEFAULT 1,
+      advance_mode   TEXT DEFAULT 'sessions',
+      on_complete    TEXT DEFAULT 'hold',
       created_at  TEXT DEFAULT (datetime('now')),
       updated_at  TEXT DEFAULT (datetime('now')),
       deleted_at  TEXT,
@@ -197,6 +200,9 @@ async function _createSchema(db) {
       assigned_by INTEGER,
       start_date  TEXT,
       active      INTEGER DEFAULT 1,
+      week_cursor              INTEGER,
+      week_cursor_session_base INTEGER,
+      week_cursor_pinned_at    TEXT,
       assigned_at TEXT DEFAULT (datetime('now')),
       updated_at  TEXT DEFAULT (datetime('now')),
       deleted_at  TEXT,
@@ -215,6 +221,7 @@ async function _createSchema(db) {
       notes        TEXT,
       duration_min REAL,
       completed    INTEGER DEFAULT 0,
+      program_week INTEGER,
       created_at   TEXT DEFAULT (datetime('now')),
       updated_at   TEXT DEFAULT (datetime('now')),
       deleted_at   TEXT,
@@ -289,6 +296,15 @@ async function _createSchema(db) {
     `ALTER TABLE program_assignments ADD COLUMN updated_at TEXT DEFAULT (datetime('now'))`,
     `ALTER TABLE program_assignments ADD COLUMN deleted_at TEXT`,
     `ALTER TABLE ai_chat_history     ADD COLUMN updated_at TEXT DEFAULT (datetime('now'))`,
+    // Multi-week progression (issue #13). Additive columns that existing
+    // local databases won't have from their original CREATE TABLE.
+    `ALTER TABLE programs            ADD COLUMN duration_weeks INTEGER DEFAULT 1`,
+    `ALTER TABLE programs            ADD COLUMN advance_mode TEXT DEFAULT 'sessions'`,
+    `ALTER TABLE programs            ADD COLUMN on_complete TEXT DEFAULT 'hold'`,
+    `ALTER TABLE program_assignments ADD COLUMN week_cursor INTEGER`,
+    `ALTER TABLE program_assignments ADD COLUMN week_cursor_session_base INTEGER`,
+    `ALTER TABLE program_assignments ADD COLUMN week_cursor_pinned_at TEXT`,
+    `ALTER TABLE workout_log         ADD COLUMN program_week INTEGER`,
   ];
   for (const stmt of _alters) {
     try { await db.execute(stmt); } catch { /* duplicate column / table missing — fine */ }

--- a/src/lib/programWeek.js
+++ b/src/lib/programWeek.js
@@ -1,19 +1,16 @@
 /**
- * programWeek.js — resolve an athlete's current plan week for a multi-week
- * progression program (issue #13).
+ * programWeek.js — client mirror of server/lib/programWeek.js (issue #13).
  *
- * A program has `duration_weeks` (default 1 = non-progressed), an
- * `advance_mode` ('sessions' | 'calendar') and an `on_complete` policy
- * ('hold' | 'repeat'). The assignment may carry a manual `week_cursor`
- * (with `week_cursor_session_base`) so the athlete can repeat/regress a week.
+ * The standalone (offline) Android build resolves an athlete's current plan
+ * week locally, since there's no server to compute `current_week` for it.
+ * Keep this in lock-step with server/lib/programWeek.js — same inputs, same
+ * output — so a workout resolves to the same week whether the app is online
+ * (server-computed) or offline (computed here).
  *
- * Used by routes/programs.js now; importable by AI/coaching context later.
- */
-
-/**
  * @param {object} program    - programs row (duration_weeks, advance_mode, on_complete)
  * @param {object} assignment - program_assignments row (start_date, assigned_at,
- *                               week_cursor, week_cursor_session_base) — may be null
+ *                               week_cursor, week_cursor_session_base,
+ *                               week_cursor_pinned_at) — may be null
  * @param {object} opts
  * @param {number} opts.sessionsInProgram - completed program-attributed sessions
  * @param {number} opts.sessionsPerWeek   - workouts that make up one plan week
@@ -29,8 +26,7 @@ export function currentPlanWeek(program, assignment, { sessionsInProgram = 0, se
   if (cursor != null) {
     // Manual pin: current week starts at the cursor and auto-advances past it
     // so repeating a week doesn't strand the athlete there forever. Advance by
-    // the same clock the program uses — calendar weeks since the pin, or
-    // sessions logged after it.
+    // the same clock the program uses.
     if (mode === 'calendar') {
       const pinnedAt = assignment?.week_cursor_pinned_at;
       const since = pinnedAt ? new Date(pinnedAt).getTime() : Date.now();
@@ -47,14 +43,11 @@ export function currentPlanWeek(program, assignment, { sessionsInProgram = 0, se
     const days = Math.max(0, Math.floor((Date.now() - since) / 86400000));
     week = Math.floor(days / 7) + 1;
   } else {
-    // Default: advance by sessions completed.
     week = Math.floor(sessionsInProgram / perWeek) + 1;
   }
 
   if (program?.on_complete === 'repeat') {
-    // Loop back to week 1 past the end. week is 1-based.
     return ((week - 1) % duration + duration) % duration + 1;
   }
-  // Hold on the final week (and never below week 1).
   return Math.min(duration, Math.max(1, week));
 }

--- a/src/lib/sync.js
+++ b/src/lib/sync.js
@@ -246,11 +246,12 @@ async function _applyPrograms(rows, result) {
     if (p.deleted_at) { await dbRun(`DELETE FROM programs WHERE id = ?`, [p.id]); continue; }
     if (await _localIsPending('programs', 'id', p.id)) continue;
     await dbRun(
-      `INSERT OR REPLACE INTO programs (id, name, description, goal, created_by, visibility, created_at, updated_at, sync_state)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'clean')`,
+      `INSERT OR REPLACE INTO programs (id, name, description, goal, created_by, visibility, duration_weeks, advance_mode, on_complete, created_at, updated_at, sync_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'clean')`,
       [
         p.id, p.name, p.description || null, p.goal || 'general',
         p.created_by || null, p.visibility || 'private',
+        p.duration_weeks ?? 1, p.advance_mode || 'sessions', p.on_complete || 'hold',
         p.created_at || new Date().toISOString(),
         p.updated_at || new Date().toISOString(),
       ]
@@ -283,11 +284,12 @@ async function _applyAssignments(rows, result) {
   for (const a of rows) {
     if (a.deleted_at) { await dbRun(`DELETE FROM program_assignments WHERE id = ?`, [a.id]); continue; }
     await dbRun(
-      `INSERT OR REPLACE INTO program_assignments (id, program_id, assigned_to, assigned_by, start_date, active, assigned_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO program_assignments (id, program_id, assigned_to, assigned_by, start_date, active, week_cursor, week_cursor_session_base, week_cursor_pinned_at, assigned_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         a.id, a.program_id, a.assigned_to, a.assigned_by || null,
         a.start_date || null, a.active ? 1 : 0,
+        a.week_cursor ?? null, a.week_cursor_session_base ?? null, a.week_cursor_pinned_at || null,
         a.assigned_at || new Date().toISOString(),
         a.updated_at || new Date().toISOString(),
       ]
@@ -307,14 +309,15 @@ async function _applyWorkouts(rows, result) {
     await dbRun(
       `INSERT OR REPLACE INTO workout_log
          (id, user_id, date, template_id, program_id, name, exercises,
-          notes, duration_min, completed, created_at, updated_at, sync_state)
-       VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'clean')`,
+          notes, duration_min, completed, program_week, created_at, updated_at, sync_state)
+       VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'clean')`,
       [
         w.id, w.date, w.template_id || null, w.program_id || null,
         w.name || null,
         JSON.stringify(w.exercises || []),
         w.notes || null, w.duration_min ?? null,
         w.completed ? 1 : 0,
+        w.program_week ?? null,
         w.created_at || new Date().toISOString(),
         w.updated_at || new Date().toISOString(),
       ]

--- a/src/routes/Diary.svelte
+++ b/src/routes/Diary.svelte
@@ -757,17 +757,31 @@
     } catch(e) { showError(e.message); }
   }
 
+  // Advance the plan week. Past the final week a 'repeat' block loops back to
+  // week 1 (the "step from Week 4 to Week 1" case); 'hold' can't advance past
+  // the end so the button is disabled there.
+  function advancePlanWeek() {
+    const cur = selectedProgram.current_week || 1;
+    const dur = selectedProgram.duration_weeks || 1;
+    if (cur >= dur) {
+      if (selectedProgram.on_complete === 'repeat') setPlanWeek(1);
+    } else {
+      setPlanWeek(cur + 1);
+    }
+  }
+
   // Effective prescription for a given 1-based plan week (issue #13).
   // Merges the exercise's weeks[wk-1] entry over its exercise-level defaults;
-  // absent weeks[] or week falls back to the flat target_* — full back-compat.
-  // Clamps to the last authored week entry if wk overshoots.
+  // absent weeks[] / week / a missing weeks[wk-1] slot falls back to the flat
+  // target_* base — matching WorkoutEditor's fieldFor and the design doc so
+  // the same template resolves to identical targets in both views.
   function resolveWeek(ex, wk) {
     const base = {
       sets: ex.target_sets, reps: ex.target_reps, weight: ex.target_weight,
       tempo: ex.tempo, rest_sec: ex.rest_sec,
     };
     if (!wk || !ex.weeks?.length) return base;
-    const w = ex.weeks[Math.min(wk, ex.weeks.length) - 1];
+    const w = ex.weeks[wk - 1];
     if (!w) return base;
     return {
       sets: w.sets ?? base.sets,
@@ -2222,8 +2236,8 @@
             </button>
             <span class="lw-week-label">Week {selectedProgram.current_week || 1} of {selectedProgram.duration_weeks}</span>
             <button class="lw-week-nav" title="Advance a week"
-              disabled={(selectedProgram.current_week || 1) >= selectedProgram.duration_weeks}
-              on:click={() => setPlanWeek((selectedProgram.current_week || 1) + 1)}>
+              disabled={selectedProgram.on_complete === 'hold' && (selectedProgram.current_week || 1) >= selectedProgram.duration_weeks}
+              on:click={advancePlanWeek}>
               <span class="material-symbols-rounded">chevron_right</span>
             </button>
             <button class="lw-week-auto" title="Resume automatic week tracking"

--- a/src/routes/Diary.svelte
+++ b/src/routes/Diary.svelte
@@ -746,11 +746,51 @@
     catch(e) { showError(e.message); }
   }
 
+  // Repeat/regress the current plan week (issue #13). Pass null to clear the
+  // manual pin and return to auto-advance. Re-fetches so current_week and the
+  // week-aware prefill reflect the change immediately.
+  async function setPlanWeek(week) {
+    if (!selectedProgram) return;
+    try {
+      await LtApi.setProgramWeekCursor(selectedProgram.id, week);
+      selectedProgram = await LtApi.getProgram(selectedProgram.id);
+    } catch(e) { showError(e.message); }
+  }
+
+  // Effective prescription for a given 1-based plan week (issue #13).
+  // Merges the exercise's weeks[wk-1] entry over its exercise-level defaults;
+  // absent weeks[] or week falls back to the flat target_* — full back-compat.
+  // Clamps to the last authored week entry if wk overshoots.
+  function resolveWeek(ex, wk) {
+    const base = {
+      sets: ex.target_sets, reps: ex.target_reps, weight: ex.target_weight,
+      tempo: ex.tempo, rest_sec: ex.rest_sec,
+    };
+    if (!wk || !ex.weeks?.length) return base;
+    const w = ex.weeks[Math.min(wk, ex.weeks.length) - 1];
+    if (!w) return base;
+    return {
+      sets: w.sets ?? base.sets,
+      reps: w.reps ?? base.reps,
+      weight: w.weight ?? base.weight,
+      tempo: w.tempo ?? base.tempo,
+      rest_sec: w.rest_sec ?? base.rest_sec,
+    };
+  }
+
   async function loadTemplate(template) {
     showLoadWorkout = false;
+    // Current plan week for a multi-week program — drives week-aware prefill.
+    // Only meaningful when this template's program is the active one.
+    const planWeek = selectedProgram?.is_active ? (selectedProgram?.current_week || null) : null;
     // Clone the template exercises, auto-filling from last session if enabled
     const templateExercises = await Promise.all((template.exercises || []).map(async ex => {
       const lastSets = await getLastSets(ex.exercise_id);
+      // Resolve this week's prescription. When the exercise carries a weeks[]
+      // matrix and we're inside the active program, the plan value wins over
+      // last-session progressive-overload memory for the current week.
+      const eff = resolveWeek(ex, planWeek);
+      const planWins = !!(planWeek && ex.weeks?.length);
       let sets;
       if (ex.set_specs && ex.set_specs.length > 0) {
         // Per-set targets defined in template — use them as the target weight/reps
@@ -782,16 +822,18 @@
           return set;
         });
       } else {
-        const numSets = ex.target_sets || 1;
-        // Template's uniform target weight/reps — used as the base fallback
+        const numSets = eff.sets || 1;
+        // This week's uniform target weight/reps — used as the base fallback
         // when there's no last-session history to pull from.
-        const tplWeight = parseFloat(ex.target_weight);
-        const tplReps = parseInt(ex.target_reps);
+        const tplWeight = parseFloat(eff.weight);
+        const tplReps = parseInt(eff.reps);
         const baseWeight = Number.isFinite(tplWeight) ? tplWeight : 0;
         const baseReps = Number.isFinite(tplReps) ? tplReps : 0;
-        if (lastSets) {
+        if (lastSets && !planWins) {
           // Prior session wins (progressive-overload memory), template values
-          // fill any gaps beyond what the last session had.
+          // fill any gaps beyond what the last session had. Inside a
+          // periodized block (planWins) we skip this so the plan's prescribed
+          // week isn't overwritten by last week's logged load.
           sets = Array.from({ length: numSets }, (_, i) => ({
             weight: lastSets[i]?.weight ?? lastSets[lastSets.length - 1]?.weight ?? baseWeight,
             reps: lastSets[i]?.reps ?? lastSets[lastSets.length - 1]?.reps ?? baseReps,
@@ -799,13 +841,15 @@
             notes: '',
           }));
         } else {
-          // No history — use template's planned weight/reps.
+          // No history, or plan wins — use this week's planned weight/reps.
           sets = Array.from({ length: numSets }, () => ({
             weight: baseWeight, reps: baseReps, completed: false, notes: '',
           }));
         }
       }
-      return { ...ex, sets };
+      // Surface the resolved week's tempo/rest onto the logged exercise so the
+      // rest timer (and any display) can use the plan's per-exercise values.
+      return { ...ex, tempo: eff.tempo, rest_sec: eff.rest_sec, sets };
     }));
 
     // Prepend warm-up ramp when the user has opted into auto-warm-ups and
@@ -825,6 +869,10 @@
       name: template.name,
       template_id: template.id,
       program_id: selectedProgram?.id || null,
+      // Stamp the plan week this session was performed in (issue #13) so the
+      // diary can label it and it stays accurate after the athlete advances.
+      program_week: planWeek,
+      program_duration_weeks: planWeek ? (selectedProgram?.duration_weeks || null) : null,
       exercises: withWarmups,
     });
     notes = '';
@@ -1079,7 +1127,9 @@
           startRestTimer({
             exerciseId:   nextEx.exercise_id || null,
             exerciseName: nextEx.exercise_name || '',
-            durationSec:  $restDuration,
+            // A plan's per-exercise rest (issue #13) overrides the global
+            // default when present; otherwise fall back to the user's setting.
+            durationSec:  Number(nextEx.rest_sec) > 0 ? Number(nextEx.rest_sec) : $restDuration,
           });
         }
 
@@ -1871,6 +1921,13 @@
           <span class="material-symbols-rounded title-edit-icon">edit</span>
         </button>
       {/if}
+      {#if $todayLog?.program_week}
+        <!-- Plan week this session was logged in (issue #13). Persisted on the
+             log, so it stays accurate even after the athlete advances. -->
+        <span class="week-chip" title="Program week this workout was logged in">
+          Week {$todayLog.program_week}{#if $todayLog.program_duration_weeks} of {$todayLog.program_duration_weeks}{/if}
+        </span>
+      {/if}
     </div>
   {/if}
 
@@ -2153,6 +2210,26 @@
             </button>
           {/each}
         </div>
+
+        <!-- Multi-week progression: current plan week + repeat/regress. Only
+             shown for a progressed program (duration_weeks > 1). -->
+        {#if selectedProgram?.duration_weeks > 1 && selectedProgram?.is_active}
+          <div class="lw-week-bar">
+            <button class="lw-week-nav" title="Regress a week"
+              disabled={(selectedProgram.current_week || 1) <= 1}
+              on:click={() => setPlanWeek((selectedProgram.current_week || 1) - 1)}>
+              <span class="material-symbols-rounded">chevron_left</span>
+            </button>
+            <span class="lw-week-label">Week {selectedProgram.current_week || 1} of {selectedProgram.duration_weeks}</span>
+            <button class="lw-week-nav" title="Advance a week"
+              disabled={(selectedProgram.current_week || 1) >= selectedProgram.duration_weeks}
+              on:click={() => setPlanWeek((selectedProgram.current_week || 1) + 1)}>
+              <span class="material-symbols-rounded">chevron_right</span>
+            </button>
+            <button class="lw-week-auto" title="Resume automatic week tracking"
+              on:click={() => setPlanWeek(null)}>Auto</button>
+          </div>
+        {/if}
 
         <!-- Templates list — restored to the original single-button-per-row
              layout that was reliably full-width. The info preview is now
@@ -2663,7 +2740,15 @@
   .exercise-list { padding: 12px var(--page-px); display: flex; flex-direction: column; gap: 12px; }
 
   /* Inline workout title */
-  .workout-title-row { padding: 8px var(--page-px) 0; }
+  .workout-title-row { padding: 8px var(--page-px) 0; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .week-chip {
+    flex-shrink: 0;
+    padding: 3px 10px;
+    background: var(--accent-dim); color: var(--accent);
+    border-radius: var(--radius-full);
+    font-size: 12px; font-weight: 800; white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
   .workout-title {
     display: inline-flex; align-items: center; gap: 6px;
     background: none; border: none; cursor: pointer;
@@ -3130,6 +3215,30 @@
   }
   .lw-program-btn.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
   .lw-active-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+
+  /* Current plan week + repeat/regress controls (issue #13) */
+  .lw-week-bar {
+    display: flex; align-items: center; gap: 8px;
+    margin: 0 0 12px; padding: 6px 8px;
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+  }
+  .lw-week-label { flex: 1; text-align: center; font-size: 14px; font-weight: 700; color: var(--text-1); }
+  .lw-week-nav {
+    width: 32px; height: 32px; padding: 0; flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: var(--radius-sm); color: var(--text-1); cursor: pointer;
+  }
+  .lw-week-nav:disabled { opacity: 0.35; cursor: default; }
+  .lw-week-nav .material-symbols-rounded { font-size: 20px; }
+  .lw-week-auto {
+    flex-shrink: 0; padding: 6px 10px;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: var(--radius-sm); color: var(--text-2);
+    font-size: 12px; font-weight: 700; font-family: inherit; cursor: pointer;
+  }
+  .lw-week-auto:hover { color: var(--text-1); border-color: var(--text-3); }
 
   .lw-templates {
     display: flex; flex-direction: column; gap: 4px;

--- a/src/routes/ProgramDetail.svelte
+++ b/src/routes/ProgramDetail.svelte
@@ -19,6 +19,33 @@
   let newTemplateName = '';
   let creating = false;
 
+  // Program settings sheet — duration + progression mode (issue #13)
+  let showSettings = false;
+  let settingsDuration = 1;
+  let settingsAdvance = 'sessions';
+  let settingsOnComplete = 'hold';
+  let savingSettings = false;
+  function openSettings() {
+    settingsDuration = program?.duration_weeks || 1;
+    settingsAdvance = program?.advance_mode || 'sessions';
+    settingsOnComplete = program?.on_complete || 'hold';
+    showSettings = true;
+  }
+  async function saveSettings() {
+    if (savingSettings) return;
+    savingSettings = true;
+    try {
+      const dw = Math.min(52, Math.max(1, parseInt(settingsDuration) || 1));
+      const updated = await LtApi.updateProgram(params.id, {
+        duration_weeks: dw, advance_mode: settingsAdvance, on_complete: settingsOnComplete,
+      });
+      program = updated?.id ? { ...program, ...updated } : { ...program, duration_weeks: dw, advance_mode: settingsAdvance, on_complete: settingsOnComplete };
+      showSettings = false;
+      showSuccess('Program settings saved');
+    } catch(e) { showError(e.message); }
+    savingSettings = false;
+  }
+
   // Assign-to-member sheet (trainer/admin)
   let showAssign = false;
   let assignMembers = [];
@@ -172,6 +199,9 @@
         name: _nextCopyName(program.name, existingNames),
         description: program.description,
         goal: program.goal,
+        duration_weeks: program.duration_weeks,
+        advance_mode: program.advance_mode,
+        on_complete: program.on_complete,
       });
       // Copy all templates
       for (const t of program.templates || []) {
@@ -231,6 +261,7 @@
   $: programMenuActions = (() => {
     const items = [];
     if (isOwner)                items.push({ label: 'Rename',           icon: 'edit',           value: 'rename' });
+    if (isOwner)                items.push({ label: 'Duration & progression', icon: 'tune',     value: 'settings' });
     /* Duplicate is available to anyone viewing the program (matches
        the previous unconditional Duplicate icon behaviour). */
                                 items.push({ label: 'Duplicate',        icon: 'content_copy',   value: 'duplicate' });
@@ -241,6 +272,7 @@
   function onProgramMenuSelect(e) {
     const v = e.detail?.value;
     if      (v === 'rename')    startRename();
+    else if (v === 'settings')  openSettings();
     else if (v === 'duplicate') duplicateProgram();
     else if (v === 'assign')    openAssign();
     else if (v === 'delete')    deleteProgram();
@@ -291,6 +323,11 @@
       <div class="info-bar">
         <span class="goal-tag">{program.goal}</span>
         <span class="template-count">{program.templates?.length || 0} workouts</span>
+        {#if program.duration_weeks > 1}
+          <span class="goal-tag">
+            {program.is_active && program.current_week ? `Week ${program.current_week} of ${program.duration_weeks}` : `${program.duration_weeks} weeks`}
+          </span>
+        {/if}
         {#if program.is_active}
           <button class="active-badge" on:click={deactivate} title="Tap to Deactivate">
             <span class="material-symbols-rounded" style="font-size:14px">check_circle</span>
@@ -384,6 +421,40 @@
         </button>
       {/each}
     {/if}
+  </div>
+</Sheet>
+
+<!-- Duration & progression settings (issue #13) -->
+<Sheet open={showSettings} on:close={() => showSettings = false}>
+  <div class="form-sheet">
+    <h3 class="form-title">Duration & progression</h3>
+    <div class="form-group">
+      <label class="form-label">Duration (weeks)</label>
+      <input class="form-input" type="number" min="1" max="52" bind:value={settingsDuration} placeholder="1" />
+      <p class="form-hint">More than 1 enables a per-week progression matrix in the workout editor.</p>
+    </div>
+    {#if settingsDuration > 1}
+      <div class="form-group">
+        <label class="form-label">Advance the week by</label>
+        <select class="form-select" bind:value={settingsAdvance}>
+          <option value="sessions">Sessions completed</option>
+          <option value="calendar">Calendar (7 days per week)</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Past the final week</label>
+        <select class="form-select" bind:value={settingsOnComplete}>
+          <option value="hold">Hold on the final week</option>
+          <option value="repeat">Repeat from week 1</option>
+        </select>
+      </div>
+    {/if}
+    <div class="form-actions">
+      <button class="btn btn-secondary" on:click={() => showSettings = false}>Cancel</button>
+      <button class="btn btn-primary" on:click={saveSettings} disabled={savingSettings}>
+        {savingSettings ? 'Saving...' : 'Save'}
+      </button>
+    </div>
   </div>
 </Sheet>
 
@@ -535,13 +606,14 @@
   .form-title { font-size: 20px; font-weight: 700; color: var(--text-1); margin: 0 0 20px; }
   .form-group { margin-bottom: 16px; }
   .form-label { display: block; font-size: 13px; font-weight: 600; color: var(--text-2); margin-bottom: 6px; }
-  .form-input {
+  .form-input, .form-select {
     width: 100%; padding: 12px 14px;
     background: var(--surface-2); border: 1px solid var(--border);
     border-radius: var(--radius-md); color: var(--text-1);
     font-size: 15px; font-family: inherit; outline: none;
   }
-  .form-input:focus { border-color: var(--accent); }
+  .form-input:focus, .form-select:focus { border-color: var(--accent); }
+  .form-hint { margin: 6px 0 0; font-size: 12px; color: var(--text-3); line-height: 1.4; }
   .form-actions { display: flex; gap: 10px; margin-top: 24px; }
   .form-actions button { flex: 1; padding: 13px; font-size: 15px; }
 

--- a/src/routes/Programs.svelte
+++ b/src/routes/Programs.svelte
@@ -18,6 +18,7 @@
   let showCreate = false;
   let newName = '';
   let newGoal = 'general';
+  let newDurationWeeks = 1;
   let creating = false;
 
   // Re-fetch when a background sync brings updates (native+server mode).
@@ -44,10 +45,11 @@
     if (!newName.trim() || creating) return;
     creating = true;
     try {
-      const p = await LtApi.createProgram({ name: newName.trim(), goal: newGoal });
+      const p = await LtApi.createProgram({ name: newName.trim(), goal: newGoal, duration_weeks: newDurationWeeks });
       showCreate = false;
       newName = '';
       newGoal = 'general';
+      newDurationWeeks = 1;
       push(`/programs/${p.id}`);
     } catch(e) { showError(e.message); }
     creating = false;
@@ -118,7 +120,9 @@
                  getting too tall. Program detail page has the full list. -->
             {#if p.is_active && (p.weeks_active > 0 || p.sessions_in_program > 0)}
               <div class="card-progress">
-                {#if p.weeks_active > 0}
+                {#if p.duration_weeks > 1 && p.current_week}
+                  <span class="progress-stat">Week {p.current_week} of {p.duration_weeks}</span>
+                {:else if p.weeks_active > 0}
                   <span class="progress-stat">Week {p.weeks_active}</span>
                 {/if}
                 {#if p.sessions_in_program > 0}
@@ -148,6 +152,12 @@
       <select class="form-select" bind:value={newGoal}>
         {#each GOALS as g}<option value={g.id}>{g.label}</option>{/each}
       </select>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Duration (weeks)</label>
+      <input class="form-input" type="number" min="1" max="52" bind:value={newDurationWeeks}
+        placeholder="1" />
+      <p class="form-hint">Weeks in this training block. More than 1 enables per-week progression (different sets/reps/tempo/rest each week).</p>
     </div>
     <div class="form-actions">
       <button class="btn btn-secondary" on:click={() => showCreate = false}>Cancel</button>
@@ -238,6 +248,7 @@
     font-size: 15px; font-family: inherit; outline: none;
   }
   .form-input:focus, .form-select:focus { border-color: var(--accent); }
+  .form-hint { margin: 6px 0 0; font-size: 12px; color: var(--text-3); line-height: 1.4; }
   .form-actions { display: flex; gap: 10px; margin-top: 24px; }
   .form-actions button { flex: 1; padding: 13px; font-size: 15px; }
 

--- a/src/routes/WorkoutEditor.svelte
+++ b/src/routes/WorkoutEditor.svelte
@@ -443,6 +443,107 @@
     template.exercises = updated;
   }
 
+  // ── Multi-week progression matrix (issue #13) ───────────────────────
+  // A program's duration_weeks (joined onto the template) drives a Week tab
+  // strip. Week 1 keeps mirroring the flat target_* / exercise-level defaults
+  // (full back-compat); weeks 2..N live in the exercise's optional weeks[]
+  // array. Field name mapping between the strip's fields and the flat keys:
+  const FLAT_FIELD = { sets: 'target_sets', reps: 'target_reps', weight: 'target_weight', tempo: 'tempo', rest_sec: 'rest_sec' };
+  $: durationWeeks = template?.duration_weeks || 1;
+  let activeWeek = 1;
+  $: if (activeWeek > durationWeeks) activeWeek = durationWeeks;
+
+  // Read a field's value for a specific plan week (1-based). Week 1 (or a
+  // non-progressed program) reads the flat keys; later weeks read weeks[wk-1].
+  function fieldFor(ex, field, wk) {
+    if (durationWeeks <= 1 || wk === 1) {
+      const v = ex?.[FLAT_FIELD[field]];
+      return v == null ? '' : v;
+    }
+    const v = ex?.weeks?.[wk - 1]?.[field];
+    return v == null ? '' : v;
+  }
+  // `wk` is passed explicitly (always `activeWeek`) at every call site so the
+  // template expression names activeWeek and Svelte re-reads the field when
+  // you switch weeks. Reading activeWeek only inside the body wouldn't create
+  // that dependency, so the inputs would stay stuck on week 1.
+  function weekVal(ex, field, wk) { return fieldFor(ex, field, wk); }
+
+  // Write a field for the active week. Empty clears the key so sparse week
+  // rows inherit the exercise-level default (matches the diary's resolveWeek).
+  function setWeekVal(idx, field, value) {
+    const empty = value === '' || value == null || (typeof value === 'number' && Number.isNaN(value));
+    if (durationWeeks <= 1 || activeWeek === 1) {
+      const fallback = (field === 'sets' || field === 'rest_sec') ? 0 : '';
+      updateExercise(idx, FLAT_FIELD[field], empty ? fallback : value);
+      return;
+    }
+    const updated = [...exercises];
+    const ex = { ...updated[idx] };
+    const weeks = [...(ex.weeks || [])];
+    while (weeks.length < activeWeek) weeks.push(null);
+    const entry = { ...(weeks[activeWeek - 1] || {}) };
+    if (empty) delete entry[field];
+    else entry[field] = value;
+    weeks[activeWeek - 1] = entry;
+    ex.weeks = weeks;
+    updated[idx] = ex;
+    template.exercises = updated;
+  }
+
+  const WEEK_FIELDS = ['sets', 'reps', 'weight', 'tempo', 'rest_sec'];
+
+  // Return a copy of `ex` with week `src`'s effective values written into
+  // week `dst`'s entry (creating the sparse array slot as needed).
+  function withWeekCopied(ex, src, dst) {
+    const nx = { ...ex };
+    const weeks = [...(nx.weeks || [])];
+    while (weeks.length < dst) weeks.push(null);
+    const entry = {};
+    for (const f of WEEK_FIELDS) {
+      const v = fieldFor(ex, f, src);
+      if (v !== '' && v != null) entry[f] = v;
+    }
+    weeks[dst - 1] = entry;
+    nx.weeks = weeks;
+    return nx;
+  }
+
+  // Does exercise `ex`'s week `wk` prescription differ from week `wk+1`'s?
+  // Drives the "dirty" state of the copy controls — copying is only offered
+  // when it would actually change the next week. `wk`/`dw` are passed
+  // explicitly so the template expressions depend on activeWeek/durationWeeks
+  // and re-evaluate when you switch weeks.
+  function weekDiffersFromNext(ex, wk, dw) {
+    if (wk >= dw) return false;
+    return WEEK_FIELDS.some(f =>
+      String(fieldFor(ex, f, wk) ?? '') !== String(fieldFor(ex, f, wk + 1) ?? '')
+    );
+  }
+
+  // Strip-level: is there any exercise whose current week differs from next?
+  $: canCopyWeek = activeWeek < durationWeeks
+    && exercises.some(ex => weekDiffersFromNext(ex, activeWeek, durationWeeks));
+
+  // Duplicate the active week's uniform prescription into the next week for
+  // every exercise — coaches typically fill Week 1 then tweak later weeks.
+  // Advances to the copied week so the result is visible for tweaking.
+  function copyWeekToNext() {
+    if (activeWeek >= durationWeeks) return;
+    const src = activeWeek, dst = activeWeek + 1;
+    template.exercises = exercises.map(ex => withWeekCopied(ex, src, dst));
+    activeWeek = dst;
+  }
+
+  // Per-exercise: copy just this exercise's active-week values into next week.
+  // Stays on the current week so the coach can keep copying/tweaking others.
+  function copyExerciseWeekToNext(idx) {
+    if (activeWeek >= durationWeeks) return;
+    const updated = [...exercises];
+    updated[idx] = withWeekCopied(updated[idx], activeWeek, activeWeek + 1);
+    template.exercises = updated;
+  }
+
   // ── Per-set targets (e.g. pyramid sets) ─────────────────────────────
   // When ex.set_specs is an array, each set has its own {weight, reps}.
   // When absent, the uniform target_sets × target_reps @ target_weight is used.
@@ -583,6 +684,26 @@
     <Spinner block label="Loading template…" />
   {:else if template}
     <div class="content">
+      {#if durationWeeks > 1}
+        <!-- Week tab strip — switches which plan week's targets are edited.
+             The copy arrow sits between the active week and the next, and is
+             only enabled when the current week actually differs from next. -->
+        <div class="week-strip">
+          {#each Array(durationWeeks) as _, i}
+            <button class="week-tab" class:active={activeWeek === i + 1} on:click={() => activeWeek = i + 1}>
+              Week {i + 1}
+            </button>
+            {#if activeWeek === i + 1 && i + 1 < durationWeeks}
+              <button class="week-copy-arrow" disabled={!canCopyWeek}
+                on:click={copyWeekToNext}
+                title={canCopyWeek ? `Copy Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
+                aria-label="Copy this week into the next week">
+                <span class="material-symbols-rounded">arrow_forward</span>
+              </button>
+            {/if}
+          {/each}
+        </div>
+      {/if}
       {#if exercises.length === 0}
         <div class="empty">
           <span class="material-symbols-rounded">playlist_add</span>
@@ -642,6 +763,14 @@
                         <button type="button" class="btn-icon-sm" on:click|stopPropagation={() => openExInfo(idx)} title="View exercise details" aria-label="View exercise details">
                           <span class="material-symbols-rounded">info</span>
                         </button>
+                        {#if durationWeeks > 1 && activeWeek < durationWeeks}
+                          <button type="button" class="ex-week-copy" disabled={!weekDiffersFromNext(ex, activeWeek, durationWeeks)}
+                            on:click|stopPropagation={() => copyExerciseWeekToNext(idx)}
+                            title={weekDiffersFromNext(ex, activeWeek, durationWeeks) ? `Copy this exercise's Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
+                            aria-label="Copy this exercise into Week {activeWeek + 1}">
+                            <span class="material-symbols-rounded">arrow_forward</span>{activeWeek + 1}
+                          </button>
+                        {/if}
                         <button type="button" class="btn-icon-sm" on:click|stopPropagation={() => openExActions(idx)} title="Options">
                           <span class="material-symbols-rounded">more_vert</span>
                         </button>
@@ -695,15 +824,25 @@
                         <div class="ex-fields three-col">
                           <div class="field">
                             <label>Sets</label>
-                            <input type="number" value={ex.target_sets || ''} on:input={e => updateExercise(idx, 'target_sets', parseInt(e.target.value) || 0)} placeholder="—" />
+                            <input type="number" value={weekVal(ex, 'sets', activeWeek)} on:input={e => setWeekVal(idx, 'sets', parseInt(e.target.value))} placeholder="—" />
                           </div>
                           <div class="field">
                             <label>Reps</label>
-                            <input type="text" value={ex.target_reps || ''} on:input={e => updateExercise(idx, 'target_reps', e.target.value)} placeholder="e.g. 8-12" />
+                            <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder="e.g. 8-12" />
                           </div>
                           <div class="field">
                             <label>Weight</label>
-                            <input type="text" value={ex.target_weight || ''} on:input={e => updateExercise(idx, 'target_weight', e.target.value)} placeholder="e.g. 135" />
+                            <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder="e.g. 135" />
+                          </div>
+                        </div>
+                        <div class="ex-fields two-col">
+                          <div class="field">
+                            <label>Tempo</label>
+                            <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder="e.g. 3.1.1" />
+                          </div>
+                          <div class="field">
+                            <label>Rest (s)</label>
+                            <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder="e.g. 90" />
                           </div>
                         </div>
                         <button class="per-set-link" on:click={() => enablePerSet(idx)}>
@@ -753,6 +892,14 @@
                 <button type="button" class="btn-icon-sm" on:click|stopPropagation={() => openExInfo(idx)} title="View exercise details" aria-label="View exercise details">
                   <span class="material-symbols-rounded">info</span>
                 </button>
+                {#if durationWeeks > 1 && activeWeek < durationWeeks}
+                  <button type="button" class="ex-week-copy" disabled={!weekDiffersFromNext(ex, activeWeek, durationWeeks)}
+                    on:click|stopPropagation={() => copyExerciseWeekToNext(idx)}
+                    title={weekDiffersFromNext(ex, activeWeek, durationWeeks) ? `Copy this exercise's Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
+                    aria-label="Copy this exercise into Week {activeWeek + 1}">
+                    <span class="material-symbols-rounded">arrow_forward</span>{activeWeek + 1}
+                  </button>
+                {/if}
                 <button type="button" class="btn-icon-sm" on:click|stopPropagation={() => openExActions(idx)} title="Options">
                   <span class="material-symbols-rounded">more_vert</span>
                 </button>
@@ -806,15 +953,25 @@
                 <div class="ex-fields three-col">
                   <div class="field">
                     <label>Sets</label>
-                    <input type="number" value={ex.target_sets || 3} on:input={e => updateExercise(idx, 'target_sets', parseInt(e.target.value) || 1)} />
+                    <input type="number" value={weekVal(ex, 'sets', activeWeek)} on:input={e => setWeekVal(idx, 'sets', parseInt(e.target.value))} placeholder="—" />
                   </div>
                   <div class="field">
                     <label>Reps</label>
-                    <input type="text" value={ex.target_reps || ''} on:input={e => updateExercise(idx, 'target_reps', e.target.value)} placeholder="e.g. 8-12" />
+                    <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder="e.g. 8-12" />
                   </div>
                   <div class="field">
                     <label>Weight</label>
-                    <input type="text" value={ex.target_weight || ''} on:input={e => updateExercise(idx, 'target_weight', e.target.value)} placeholder="e.g. 135" />
+                    <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder="e.g. 135" />
+                  </div>
+                </div>
+                <div class="ex-fields two-col">
+                  <div class="field">
+                    <label>Tempo</label>
+                    <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder="e.g. 3.1.1" />
+                  </div>
+                  <div class="field">
+                    <label>Rest (s)</label>
+                    <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder="e.g. 90" />
                   </div>
                 </div>
                 <button class="per-set-link" on:click={() => enablePerSet(idx)}>
@@ -1027,11 +1184,56 @@
   }
   .ex-name { flex: 1; font-size: 14px; font-weight: 600; color: var(--text-1); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .btn-icon-sm { background: none; border: none; cursor: pointer; color: var(--text-3); padding: 4px; display: flex; border-radius: var(--radius-xs); flex-shrink: 0; }
-  .btn-icon-sm:hover { color: var(--text-1); background: var(--surface-2); }
+  .btn-icon-sm:hover:not(:disabled) { color: var(--text-1); background: var(--surface-2); }
+  .btn-icon-sm:disabled { opacity: 0.35; cursor: default; }
+
+  /* Per-exercise "copy into next week" pill — shows an arrow to the target
+     week number (e.g. "→2" on Week 1). Disabled when nothing to copy. */
+  .ex-week-copy {
+    display: inline-flex; align-items: center; gap: 1px;
+    flex-shrink: 0; padding: 3px 9px 3px 4px;
+    background: var(--accent-dim); border: none;
+    border-radius: var(--radius-full); color: var(--accent);
+    font-size: 12px; font-weight: 800; font-family: inherit;
+    font-variant-numeric: tabular-nums; cursor: pointer;
+    transition: background var(--dur-fast), color var(--dur-fast), opacity var(--dur-fast);
+  }
+  .ex-week-copy:hover:not(:disabled) { background: var(--accent); color: var(--accent-text); }
+  .ex-week-copy:disabled { opacity: 0.35; cursor: default; }
+  .ex-week-copy .material-symbols-rounded { font-size: 16px; }
 
   .ex-fields { display: grid; gap: 8px; margin-bottom: 4px; }
   .two-col { grid-template-columns: 1fr 1fr; }
   .three-col { grid-template-columns: 1fr 1fr 1fr; }
+
+  /* ── Week tab strip (multi-week progression, issue #13) ─────────── */
+  .week-strip {
+    display: flex; align-items: center; gap: 6px;
+    overflow-x: auto; -webkit-overflow-scrolling: touch;
+    padding-bottom: 4px; margin-bottom: 12px;
+  }
+  .week-strip::-webkit-scrollbar { display: none; }
+  .week-tab {
+    flex-shrink: 0; padding: 7px 14px;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: var(--radius-full); color: var(--text-2);
+    font-size: 13px; font-weight: 700; font-family: inherit; cursor: pointer;
+    white-space: nowrap;
+    transition: background var(--dur-fast), border-color var(--dur-fast), color var(--dur-fast);
+  }
+  .week-tab:hover { color: var(--text-1); }
+  .week-tab.active { background: var(--accent-dim); border-color: var(--accent); color: var(--accent); }
+  /* Copy arrow sits inline between the active week chip and the next one. */
+  .week-copy-arrow {
+    flex-shrink: 0; width: 28px; height: 28px; padding: 0;
+    display: flex; align-items: center; justify-content: center;
+    background: none; border: none; cursor: pointer;
+    color: var(--accent);
+    transition: color var(--dur-fast), opacity var(--dur-fast), transform var(--dur-fast);
+  }
+  .week-copy-arrow:hover:not(:disabled) { transform: translateX(1px); }
+  .week-copy-arrow:disabled { color: var(--text-3); opacity: 0.4; cursor: default; }
+  .week-copy-arrow .material-symbols-rounded { font-size: 20px; }
   .field label { display: block; font-size: 11px; color: var(--text-3); margin-bottom: 3px; font-weight: 600; text-transform: uppercase; }
   .field input {
     width: 100%; background: var(--surface-2); border: 1px solid var(--border);

--- a/src/stores/workout.js
+++ b/src/stores/workout.js
@@ -61,6 +61,7 @@ async function _mergeAndSave(dateStr, clientEntry) {
     duration_min: clientEntry.duration_min ?? server.duration_min,
     template_id:  clientEntry.template_id  ?? server.template_id,
     program_id:   clientEntry.program_id   ?? server.program_id,
+    program_week: clientEntry.program_week ?? server.program_week,
   } : clientEntry;
   return LtApi.saveWorkout(dateStr, toSave);
 }


### PR DESCRIPTION
Implements **Phase 1** of #13 — multi-week progression plans.

A program's workout templates can now prescribe a different **Sets / Reps / Tempo / Rest / Load** each week, the app resolves the athlete's **current week**, and the Diary prefills that week's targets on load. Fully additive and backward-compatible: `duration_weeks` defaults to `1` (today's flat-prescription behaviour), and the per-week matrix lives in optional `weeks[] / tempo / rest_sec` keys inside the existing template JSON — no breaking migration.

## Backend
- **Schema** (additive, idempotent): `programs.duration_weeks / advance_mode / on_complete`; `program_assignments.week_cursor` (+ session base) for repeat/regress; `workout_log.program_week` to stamp the week a session was logged in.
- **`lib/programWeek.js`** resolves the current plan week — session-based by default, calendar optional; holds or repeats past the final week; a manual cursor pins the week then resumes advancing relative to the pin.
- Surface `current_week` on `GET /api/programs` and `/:id`; accept the new program fields on `POST`/`PUT`; add `POST /:id/week-cursor`.
- Join `duration_weeks` onto `GET /api/templates/:id`; return it plus the stamped `program_week` from `GET /api/workout/:date`. Thread `program_week` through the save route and **both** sync paths.

## Frontend
- **WorkoutEditor**: Week tab strip, per-week Tempo/Rest fields, an inline copy arrow between weeks, and a per-exercise "→N" copy pill — both disabled when the next week already matches.
- **Diary**: week-aware prefill (the plan wins over last-session auto-fill inside a programmed block), per-exercise rest drives the rest timer, "Week N of M" + repeat/regress controls in the Load-Workout sheet, and a persisted week chip on the logged workout.
- **Programs / ProgramDetail**: set duration + advance/on-complete, plus card and detail week chips.

## Notes
- `CHANGELOG.md` updated under Unreleased; PR targets `dev` per CONTRIBUTING.
- Out of scope (per the issue): XLSX import, auto-scheduling templates to weekdays, deload auto-suggestion.
