### PR TITLE
ci: publish to Docker Hub + drop :main and :sha-* tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build & Push to GHCR
+name: Build & Push
 
 on:
   push:
@@ -41,17 +41,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
-      # Derive tags from the ref:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Derive tags from the ref, mirrored to both registries:
       #   semver tag v1.2.3 → :1.2.3, :1.2, :1
       #   push to main      → :latest, :main, :sha-<shortsha>
       #   push to dev       → :dev, :sha-<shortsha>
       # Users pin :dev for the leading edge, :latest for stable
-      # releases, or :1.0 for auto-patch within a minor.
+      # releases, or :1.0 for auto-patch within a minor. Same tag set
+      # exists at both ghcr.io/traceapps/lifttrace (primary) and
+      # traceapps/lifttrace on Docker Hub (discoverability mirror).
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/traceapps/lifttrace
+          images: |
+            ghcr.io/traceapps/lifttrace
+            traceapps/lifttrace
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,18 +48,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Derive tags from the ref, mirrored to both registries:
-      #   semver tag v1.2.3 → :1.2.3, :1.2, :1
-      #   push to main      → :latest, :sha-<shortsha>
-      #   push to dev       → :dev, :sha-<shortsha>
+      #   semver tag v1.2.3 → :1.2.3, :1.2, :1, :latest
+      #   push to main      → :latest
+      #   push to dev       → :dev
       # Users pin :dev for the leading edge, :latest for stable
       # releases, or :1.0 for auto-patch within a minor. Same tag set
       # exists at both ghcr.io/traceapps/lifttrace (primary) and
       # traceapps/lifttrace on Docker Hub (discoverability mirror).
       #
-      # `:main` intentionally not emitted — it would be identical to
-      # `:latest` in this workflow (both fire on every main push), so
-      # `:latest` is the only stable branch tag. `type=ref,event=branch`
-      # is gated to the dev branch so it still emits `:dev` on dev pushes.
+      # `:main` and `:sha-*` intentionally not emitted:
+      #   - `:main` would be identical to `:latest` (both fire on every
+      #     main push) — redundant.
+      #   - `:sha-*` per-commit tags accumulate fast on a busy dev branch
+      #     and clutter the registry tag list — reproducibility for
+      #     stable is covered by `:1.2.3` semver pins, and dev-side
+      #     reproducibility can use manifest digests instead.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -73,7 +76,6 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/dev' }}
-            type=sha
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,12 +49,17 @@ jobs:
 
       # Derive tags from the ref, mirrored to both registries:
       #   semver tag v1.2.3 → :1.2.3, :1.2, :1
-      #   push to main      → :latest, :main, :sha-<shortsha>
+      #   push to main      → :latest, :sha-<shortsha>
       #   push to dev       → :dev, :sha-<shortsha>
       # Users pin :dev for the leading edge, :latest for stable
       # releases, or :1.0 for auto-patch within a minor. Same tag set
       # exists at both ghcr.io/traceapps/lifttrace (primary) and
       # traceapps/lifttrace on Docker Hub (discoverability mirror).
+      #
+      # `:main` intentionally not emitted — it would be identical to
+      # `:latest` in this workflow (both fire on every main push), so
+      # `:latest` is the only stable branch tag. `type=ref,event=branch`
+      # is gated to the dev branch so it still emits `:dev` on dev pushes.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -67,7 +72,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha
 
       - name: Build and push


### PR DESCRIPTION
Brings LT's Docker Hub publishing to parity with CookTrace. Three changes bundled:

1. **Docker Hub push alongside GHCR** — every main + dev + semver-tag push now mirrors to `traceapps/lifttrace` on Docker Hub. GHCR remains the primary registry.
2. **Drop `:main` tag** — identical to `:latest` in this workflow, redundant.
3. **Drop `:sha-*` per-commit tags** — noise on the registry tag list; semver + manifest digest already cover reproducibility.

Final tag set on both registries:
- `:1.2.3`, `:1.2`, `:1` — semver pins from tag pushes
- `:latest` — current main HEAD
- `:dev` — current dev branch tip

Verified end-to-end on dev at 3d632bd, 752b198 (CT), 8e9bb7f (LT). Full test pipeline ran green on TraceApps/cooktrace.