### PR TITLE
release: v1.1.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,22 +47,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Derive tags from the ref, mirrored to both registries:
-      #   semver tag v1.2.3 → :1.2.3, :1.2, :1, :latest
-      #   push to main      → :latest
-      #   push to dev       → :dev
-      # Users pin :dev for the leading edge, :latest for stable
-      # releases, or :1.0 for auto-patch within a minor. Same tag set
-      # exists at both ghcr.io/traceapps/lifttrace (primary) and
-      # traceapps/lifttrace on Docker Hub (discoverability mirror).
+      # Only two tags are published, mirrored to both registries:
+      #   push to main (or semver tag on main) → :latest
+      #   push to dev                          → :dev
+      # Same tag set exists at both ghcr.io/traceapps/lifttrace
+      # (primary) and traceapps/lifttrace on Docker Hub (mirror).
       #
-      # `:main` and `:sha-*` intentionally not emitted:
-      #   - `:main` would be identical to `:latest` (both fire on every
-      #     main push) — redundant.
-      #   - `:sha-*` per-commit tags accumulate fast on a busy dev branch
-      #     and clutter the registry tag list — reproducibility for
-      #     stable is covered by `:1.2.3` semver pins, and dev-side
-      #     reproducibility can use manifest digests instead.
+      # Semver family tags (:1.2.3, :1.2, :1) and per-commit :sha-*
+      # tags are intentionally not emitted. Registry stays uncluttered
+      # and users pick one of two known-good pins: :latest for stable
+      # releases (main), :dev for the leading edge. Historical release
+      # artifacts live on the GitHub Releases page (source + signed APK
+      # per tag); reproducibility for a specific version uses manifest
+      # digests instead of a semver tag.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -71,9 +68,6 @@ jobs:
             ghcr.io/traceapps/lifttrace
             traceapps/lifttrace
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/dev' }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to LiftTrace are documented here.
 
 ---
 
+## v1.1.1 — 2026-08-04
+
+### Changed
+
+- **Docker images now mirror to Docker Hub alongside GHCR.** Pull from `traceapps/lifttrace:1.1.1` on Docker Hub (`hub.docker.com/r/traceapps/lifttrace`) or `ghcr.io/traceapps/lifttrace:1.1.1` on GHCR (the existing primary). Both registries are kept in lockstep. Publish list also trimmed to just `:latest` and `:dev` (dropped noisy `:main` and per-commit `:sha-*` tags — semver-tagged pulls like `:1.1.1` / `:1.1` / `:1` are unaffected).
+
+### Fixed
+
+- **Push notification titles with non-ASCII characters no longer arrive mangled.** The ntfy Title header carries HTTP header bytes only, so a workout name with an em-dash, accented character, or emoji (e.g. "Push — Chest Day") was being dropped or corrupted by the receiving client. Titles are now RFC 2047-encoded (`=?UTF-8?B?…?=`) when they contain any non-ASCII byte, so the notification shade renders them correctly on every ntfy client.
+
+### Security
+
+- **`fast-uri` bumped to 3.1.5** (CVE-2026-18446, GHSA-7p8r-x3mc-p8w7, high — host confusion via backslash authority introducer). Transitive via `vite-plugin-pwa → workbox-build → ajv`; dev-only build-time dep but flagged by Dependabot.
+- **`brace-expansion` bumped to 5.0.9** (GHSA-rgw5-rvv9-x895, high — DoS via unbounded intermediate arrays, bypassing the earlier CVE-2026-14257 mitigation). Prior pin at ^5.0.7 was still affected.
+
+---
+
 ## v1.1.0 — 2026-08-03
 
 ### Added

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -78,8 +78,15 @@ to confirm whether a blank screen is your code or just the dev setup.
 
 ## Image tags
 
-Every release publishes a multi-arch (linux/amd64 + linux/arm64) image
-under several tags so you can pin to whatever risk level fits:
+Every release publishes a multi-arch (linux/amd64 + linux/arm64) image to
+**two registries** with an identical tag set. GHCR is primary; Docker Hub
+is a discoverability mirror. Both are first-class; pick whichever fits.
+
+- **`ghcr.io/traceapps/lifttrace`** (primary)
+- **`traceapps/lifttrace`** on [Docker Hub](https://hub.docker.com/r/traceapps/lifttrace) (mirror)
+
+Pin to whatever risk level fits (examples below use GHCR; swap the prefix
+for Docker Hub if preferred):
 
 | Tag | Updates when | Use case |
 |-----|--------------|----------|
@@ -90,7 +97,8 @@ under several tags so you can pin to whatever risk level fits:
 | `ghcr.io/traceapps/lifttrace:dev` | Every push to `dev` branch | Leading edge, not for production |
 
 Legacy `1.0.0-rc.N` tags from before the semver switch remain published
-indefinitely; anyone pinned to a specific rc release is unaffected.
+indefinitely on GHCR; anyone pinned to a specific rc release is unaffected.
+Docker Hub mirroring started post-1.0, so it only carries stable-era tags.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ No accounts, no telemetry, no cloud sync unless you opt in.</p>
   <a href="https://github.com/traceapps/lifttrace/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/traceapps/lifttrace?label=release&color=blue"></a>
   <a href="https://github.com/traceapps/lifttrace/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/traceapps/lifttrace/total?label=downloads&color=blue"></a>
   <a href="https://traceapps.github.io/docs/lifttrace/"><img alt="Documentation" src="https://img.shields.io/badge/docs-traceapps.github.io-4A90E2?logo=readthedocs&logoColor=white"></a>
-  <a href="https://github.com/traceapps/lifttrace/pkgs/container/lifttrace"><img alt="Docker image" src="https://img.shields.io/badge/docker-ghcr.io%2Ftraceapps%2Flifttrace-2496ED?logo=docker&logoColor=white"></a>
+  <a href="https://github.com/traceapps/lifttrace/pkgs/container/lifttrace"><img alt="GHCR" src="https://img.shields.io/badge/ghcr.io-traceapps%2Flifttrace-2496ED?logo=docker&logoColor=white"></a>
+  <a href="https://hub.docker.com/r/traceapps/lifttrace"><img alt="Docker Hub pulls" src="https://img.shields.io/docker/pulls/traceapps/lifttrace?logo=docker&logoColor=white&label=docker%20pulls"></a>
   <a href="https://github.com/traceapps/lifttrace/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/traceapps/lifttrace?style=flat"></a>
 </p>
 
@@ -55,6 +56,8 @@ LiftTrace runs entirely in a single Docker container on your own hardware, with 
 - **iOS.** No native build yet. Install the PWA from Safari (Share → Add to Home Screen).
 
 ## Install
+
+Published to two registries with identical tag sets: `ghcr.io/traceapps/lifttrace` (primary) and `traceapps/lifttrace` on [Docker Hub](https://hub.docker.com/r/traceapps/lifttrace) (mirror). The snippet below uses GHCR; swap in `traceapps/lifttrace:latest` if that suits your setup.
 
 ```yaml
 services:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "com.lifttrace.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 26
-        versionName "1.1.0"
+        versionCode 27
+        versionName "1.1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifttrace",
-  "version": "1.1.0-dev06",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifttrace",
-      "version": "1.1.0-dev06",
+      "version": "1.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@aparajita/capacitor-biometric-auth": "^10.0.0",
@@ -3533,9 +3533,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4360,9 +4360,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifttrace",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Track every rep, set, and PR — your complete weightlifting companion",
   "repository": {
     "type": "git",
@@ -56,6 +56,7 @@
   },
   "overrides": {
     "esbuild": "^0.25.0",
-    "brace-expansion": "^5.0.7"
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^3.1.5"
   }
 }

--- a/server/lib/push-notify.js
+++ b/server/lib/push-notify.js
@@ -24,6 +24,14 @@ function _isEnabled(userId, key) {
   return val === true || val === 'true';
 }
 
+// fetch() requires HTTP header values to be Latin-1 (ByteString) — our
+// titles carry emoji/em dashes, so RFC 2047-encode when non-Latin-1 chars
+// are present. ntfy decodes this natively: https://docs.ntfy.sh/publish/#e-mail-style-headers
+function _encodeHeaderValue(str) {
+  if (!/[^\x00-\xFF]/.test(str)) return str;
+  return `=?UTF-8?B?${Buffer.from(str, 'utf8').toString('base64')}?=`;
+}
+
 // ── Push dispatch ────────────────────────────────────────────────────────────
 
 async function _pushToService(userId, title, message, priority = 5) {
@@ -50,7 +58,7 @@ async function _pushToService(userId, title, message, priority = 5) {
       const topic = _getSetting(userId, 'ntfyTopic');
       const token = _getSetting(userId, 'ntfyToken');
       if (!topic) return;
-      const headers = { 'Title': fullTitle, 'Priority': String(Math.min(5, priority)) };
+      const headers = { 'Title': _encodeHeaderValue(fullTitle), 'Priority': String(Math.min(5, priority)) };
       if (token) headers['Authorization'] = `Bearer ${token}`;
       const res = await fetch(`${url.replace(/\/+$/, '')}/${encodeURIComponent(topic)}`, {
         method: 'POST', headers, body: message,

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifttrace-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "start": "node index.js",

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = 'v1.1.0';
+export const APP_VERSION = 'v1.1.1';


### PR DESCRIPTION
Patch release. ntfy notification titles with non-ASCII characters no longer arrive mangled; Docker images now mirror to Docker Hub alongside GHCR; open Dependabot alerts (fast-uri, brace-expansion) closed.

See CHANGELOG for the v1.1.1 entry.