### PR TITLE
chore(i18n): catch duplicate keys and unresolved code references in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Checks
+
+# The repo's other workflow (docker.yml) builds and publishes images; keeping
+# checks separate means a red check never blocks an image push and a slow
+# multi-arch build never delays PR feedback.
+on:
+  pull_request:
+  push:
+    branches: [ main, dev ]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Node 20 to match node:20-alpine in the Dockerfile.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: i18n check
+        run: npm run i18n:check
+
+      - name: Tests
+        run: npm test

--- a/scripts/i18n-check.cjs
+++ b/scripts/i18n-check.cjs
@@ -19,6 +19,18 @@ const path = require('path');
 
 const I18N_DIR = path.join(__dirname, '..', 'src', 'i18n');
 const SOURCE_FILE = 'en.json';
+const SRC_DIR = path.join(__dirname, '..', 'src');
+const ROOT = path.join(__dirname, '..');
+
+// Literals that look like i18n keys but are not. Keep the reason next to each.
+const IGNORED_INDIRECT = new Set([
+  // Property path inside a JSON schema for an AI function-calling tool
+  // (src/lib/aiTools.js), not a translation key.
+  'programs.id',
+]);
+
+const CALL_RE = /\$?_\(\s*(['"])([^'"]+)\1/g;
+const KEYISH_RE = /(['"])([a-z][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)+)\1/g;
 
 function flatten(obj, prefix = '') {
   const out = {};
@@ -107,6 +119,48 @@ function findDuplicateKeys(text) {
   return dups;
 }
 
+function walk(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(p));
+    else if (/\.(svelte|js)$/.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+function lineOf(text, index) {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (text[i] === '\n') line++;
+  return line;
+}
+
+/**
+ * Keys referenced from code. `direct` are $_('...') call arguments; `indirect`
+ * are key-shaped literals whose first segment is a top-level en.json key, which
+ * covers keys held in constants (e.g. Settings' SECTION_META titleKey).
+ * Each entry is { key, file, line }; the first occurrence of a key wins.
+ */
+function collectKeyRefs(topLevelKeys, files = walk(SRC_DIR)) {
+  const direct = new Map();
+  const indirect = new Map();
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    const rel = path.relative(ROOT, file).split(path.sep).join('/');
+    for (const m of text.matchAll(CALL_RE)) {
+      if (!direct.has(m[2])) direct.set(m[2], { key: m[2], file: rel, line: lineOf(text, m.index) });
+    }
+    for (const m of text.matchAll(KEYISH_RE)) {
+      const key = m[2];
+      if (direct.has(key) || indirect.has(key)) continue;
+      if (IGNORED_INDIRECT.has(key)) continue;
+      if (!topLevelKeys.has(key.split('.')[0])) continue;
+      indirect.set(key, { key, file: rel, line: lineOf(text, m.index) });
+    }
+  }
+  return { direct, indirect };
+}
+
 function loadJson(file) {
   return JSON.parse(fs.readFileSync(path.join(I18N_DIR, file), 'utf8'));
 }
@@ -152,6 +206,6 @@ function main() {
   process.exit(anyGap ? 1 : 0);
 }
 
-module.exports = { flatten, findDuplicateKeys };
+module.exports = { flatten, findDuplicateKeys, collectKeyRefs, IGNORED_INDIRECT };
 
 if (require.main === module) main();

--- a/scripts/i18n-check.cjs
+++ b/scripts/i18n-check.cjs
@@ -33,45 +33,125 @@ function flatten(obj, prefix = '') {
   return out;
 }
 
+/** Duplicate keys, as dotted paths, found by walking the raw JSON text. */
+function findDuplicateKeys(text) {
+  const dups = [];
+  let i = 0;
+  const skipWs = () => { while (i < text.length && /\s/.test(text[i])) i++; };
+
+  function readString() {
+    i++;
+    let s = '';
+    while (i < text.length) {
+      const c = text[i];
+      if (c === '\\') {
+        const n = text[i + 1];
+        if (n === 'u') { s += String.fromCharCode(parseInt(text.slice(i + 2, i + 6), 16)); i += 6; }
+        else { s += ({ n: '\n', t: '\t', r: '\r', b: '\b', f: '\f' }[n] ?? n); i += 2; }
+        continue;
+      }
+      if (c === '"') { i++; return s; }
+      s += c; i++;
+    }
+    throw new Error('unterminated string');
+  }
+
+  function parseValue(p) {
+    skipWs();
+    const c = text[i];
+    if (c === '{') return parseObject(p);
+    if (c === '[') return parseArray(p);
+    if (c === '"') { readString(); return; }
+    while (i < text.length && !/[,\]}\s]/.test(text[i])) i++;
+  }
+
+  function parseObject(p) {
+    i++;
+    const seen = new Set();
+    skipWs();
+    if (text[i] === '}') { i++; return; }
+    for (;;) {
+      skipWs();
+      if (text[i] !== '"') throw new Error(`expected key at ${i}`);
+      const key = readString();
+      const full = p ? `${p}.${key}` : key;
+      if (seen.has(key)) dups.push(full);
+      seen.add(key);
+      skipWs();
+      if (text[i] !== ':') throw new Error(`expected ':' at ${i}`);
+      i++;
+      parseValue(full);
+      skipWs();
+      if (text[i] === ',') { i++; continue; }
+      if (text[i] === '}') { i++; return; }
+      throw new Error(`unexpected ${text[i]} at ${i}`);
+    }
+  }
+
+  function parseArray(p) {
+    i++;
+    skipWs();
+    if (text[i] === ']') { i++; return; }
+    let idx = 0;
+    for (;;) {
+      parseValue(`${p}[${idx++}]`);
+      skipWs();
+      if (text[i] === ',') { i++; continue; }
+      if (text[i] === ']') { i++; return; }
+      throw new Error(`unexpected ${text[i]} at ${i}`);
+    }
+  }
+
+  skipWs();
+  parseValue('');
+  return dups;
+}
+
 function loadJson(file) {
   return JSON.parse(fs.readFileSync(path.join(I18N_DIR, file), 'utf8'));
 }
 
-const enFlat = flatten(loadJson(SOURCE_FILE));
-const enKeys = new Set(Object.keys(enFlat));
-const total = enKeys.size;
+function main() {
+  const enFlat = flatten(loadJson(SOURCE_FILE));
+  const enKeys = new Set(Object.keys(enFlat));
+  const total = enKeys.size;
 
-const allFiles = fs.readdirSync(I18N_DIR).filter(f => f.endsWith('.json') && f !== SOURCE_FILE);
+  const allFiles = fs.readdirSync(I18N_DIR).filter(f => f.endsWith('.json') && f !== SOURCE_FILE);
 
-console.log(`\ni18n status — source: ${SOURCE_FILE} (${total} keys)\n`);
+  console.log(`\ni18n status — source: ${SOURCE_FILE} (${total} keys)\n`);
 
-if (allFiles.length === 0) {
-  console.log('  No other locale files yet. Add fr.json / de.json / nl.json / etc. to src/i18n/.\n');
-  process.exit(0);
+  if (allFiles.length === 0) {
+    console.log('  No other locale files yet. Add fr.json / de.json / nl.json / etc. to src/i18n/.\n');
+    process.exit(0);
+  }
+
+  let anyGap = false;
+  for (const file of allFiles.sort()) {
+    const langFlat = flatten(loadJson(file));
+    const langKeys = new Set(Object.keys(langFlat));
+    const missing = [...enKeys].filter(k => !langKeys.has(k));
+    const orphaned = [...langKeys].filter(k => !enKeys.has(k));
+    const translated = total - missing.length;
+    const pct = ((translated / total) * 100).toFixed(0);
+    const status = missing.length === 0 && orphaned.length === 0 ? '✓' : '!';
+    console.log(`  ${status} ${file.padEnd(10)} ${translated}/${total}  ${pct.padStart(3)}%  ${missing.length} missing, ${orphaned.length} orphaned`);
+    if (missing.length || orphaned.length) anyGap = true;
+    if (missing.length > 0 && missing.length <= 10) {
+      for (const k of missing) console.log(`        missing: ${k}`);
+    } else if (missing.length > 10) {
+      console.log(`        missing: ${missing.slice(0, 5).join(', ')} ... and ${missing.length - 5} more`);
+    }
+    if (orphaned.length > 0 && orphaned.length <= 5) {
+      for (const k of orphaned) console.log(`       orphaned: ${k}`);
+    } else if (orphaned.length > 5) {
+      console.log(`       orphaned: ${orphaned.slice(0, 3).join(', ')} ... and ${orphaned.length - 3} more`);
+    }
+  }
+
+  console.log('');
+  process.exit(anyGap ? 1 : 0);
 }
 
-let anyGap = false;
-for (const file of allFiles.sort()) {
-  const langFlat = flatten(loadJson(file));
-  const langKeys = new Set(Object.keys(langFlat));
-  const missing = [...enKeys].filter(k => !langKeys.has(k));
-  const orphaned = [...langKeys].filter(k => !enKeys.has(k));
-  const translated = total - missing.length;
-  const pct = ((translated / total) * 100).toFixed(0);
-  const status = missing.length === 0 && orphaned.length === 0 ? '✓' : '!';
-  console.log(`  ${status} ${file.padEnd(10)} ${translated}/${total}  ${pct.padStart(3)}%  ${missing.length} missing, ${orphaned.length} orphaned`);
-  if (missing.length || orphaned.length) anyGap = true;
-  if (missing.length > 0 && missing.length <= 10) {
-    for (const k of missing) console.log(`        missing: ${k}`);
-  } else if (missing.length > 10) {
-    console.log(`        missing: ${missing.slice(0, 5).join(', ')} ... and ${missing.length - 5} more`);
-  }
-  if (orphaned.length > 0 && orphaned.length <= 5) {
-    for (const k of orphaned) console.log(`       orphaned: ${k}`);
-  } else if (orphaned.length > 5) {
-    console.log(`       orphaned: ${orphaned.slice(0, 3).join(', ')} ... and ${orphaned.length - 3} more`);
-  }
-}
+module.exports = { flatten, findDuplicateKeys };
 
-console.log('');
-process.exit(anyGap ? 1 : 0);
+if (require.main === module) main();

--- a/scripts/i18n-check.cjs
+++ b/scripts/i18n-check.cjs
@@ -1,14 +1,25 @@
 #!/usr/bin/env node
 /**
- * i18n-check — compare each translation file in src/i18n/ against en.json
- * and report missing / orphaned keys.
+ * i18n-check — three checks over src/i18n/ and the code that uses it.
  *
  * Usage:  npm run i18n:check
  *
- * "Missing" = key exists in en.json but not in <lang>.json — translator needs
- *             to add a translation. App will fall back to English at runtime.
- * "Orphaned" = key exists in <lang>.json but not in en.json — leftover from a
- *              renamed or removed source key. Harmless but worth cleaning up.
+ * Errors (exit 1):
+ *   1. Duplicate keys in en.json at any nesting depth. JSON.parse keeps the
+ *      last occurrence and drops the earlier ones silently, so a repeated
+ *      section makes whole blocks of copy vanish and render as raw keys. This
+ *      check scans the raw text, because after parsing the evidence is gone.
+ *   2. Keys referenced in code that don't resolve against en.json.
+ *
+ * Informational (exit 0):
+ *   3. Missing / orphaned keys in other locale files. Translating is
+ *      deliberately unhurried (see CONTRIBUTING), so a partial translation
+ *      reports but does not fail the build.
+ *
+ * Reference scanning covers literal keys in `$_('...')` calls plus key-shaped
+ * literals held in constants (e.g. Settings' SECTION_META titleKey), matched by
+ * shape and by their first segment existing in en.json. A key that reaches $_()
+ * some other way is not verified: that is a coverage gap, not a false pass.
  *
  * Stale-translation detection (English source changed but translation didn't)
  * is NOT possible from JSON alone. Convention: rename the key when meaning
@@ -166,44 +177,61 @@ function loadJson(file) {
 }
 
 function main() {
-  const enFlat = flatten(loadJson(SOURCE_FILE));
-  const enKeys = new Set(Object.keys(enFlat));
-  const total = enKeys.size;
+  const raw = fs.readFileSync(path.join(I18N_DIR, SOURCE_FILE), 'utf8');
+  const errors = [];
 
-  const allFiles = fs.readdirSync(I18N_DIR).filter(f => f.endsWith('.json') && f !== SOURCE_FILE);
+  const dups = findDuplicateKeys(raw);
+  const en = JSON.parse(raw);
+  const enKeys = new Set(Object.keys(flatten(en)));
+  const topLevel = new Set(Object.keys(en));
 
-  console.log(`\ni18n status — source: ${SOURCE_FILE} (${total} keys)\n`);
+  console.log(`\ni18n status — source: ${SOURCE_FILE} (${enKeys.size} keys)\n`);
 
-  if (allFiles.length === 0) {
-    console.log('  No other locale files yet. Add fr.json / de.json / nl.json / etc. to src/i18n/.\n');
-    process.exit(0);
+  if (dups.length) {
+    errors.push(`${dups.length} duplicate key(s) in ${SOURCE_FILE}`);
+    console.log(`  ✗ duplicate keys in ${SOURCE_FILE} — JSON.parse silently keeps the last one:`);
+    for (const d of dups) console.log(`        ${d}`);
+  } else {
+    console.log(`  ✓ no duplicate keys in ${SOURCE_FILE}`);
   }
 
-  let anyGap = false;
-  for (const file of allFiles.sort()) {
-    const langFlat = flatten(loadJson(file));
-    const langKeys = new Set(Object.keys(langFlat));
-    const missing = [...enKeys].filter(k => !langKeys.has(k));
-    const orphaned = [...langKeys].filter(k => !enKeys.has(k));
-    const translated = total - missing.length;
-    const pct = ((translated / total) * 100).toFixed(0);
-    const status = missing.length === 0 && orphaned.length === 0 ? '✓' : '!';
-    console.log(`  ${status} ${file.padEnd(10)} ${translated}/${total}  ${pct.padStart(3)}%  ${missing.length} missing, ${orphaned.length} orphaned`);
-    if (missing.length || orphaned.length) anyGap = true;
-    if (missing.length > 0 && missing.length <= 10) {
-      for (const k of missing) console.log(`        missing: ${k}`);
-    } else if (missing.length > 10) {
-      console.log(`        missing: ${missing.slice(0, 5).join(', ')} ... and ${missing.length - 5} more`);
-    }
-    if (orphaned.length > 0 && orphaned.length <= 5) {
-      for (const k of orphaned) console.log(`       orphaned: ${k}`);
-    } else if (orphaned.length > 5) {
-      console.log(`       orphaned: ${orphaned.slice(0, 3).join(', ')} ... and ${orphaned.length - 3} more`);
-    }
+  const { direct, indirect } = collectKeyRefs(topLevel);
+  const unresolved = [...direct.values(), ...indirect.values()].filter(r => !enKeys.has(r.key));
+  if (unresolved.length) {
+    errors.push(`${unresolved.length} code-referenced key(s) missing from ${SOURCE_FILE}`);
+    console.log(`  ✗ keys referenced in code but absent from ${SOURCE_FILE}:`);
+    for (const r of unresolved) console.log(`        ${r.key}  (${r.file}:${r.line})`);
+  } else {
+    console.log(`  ✓ all ${direct.size + indirect.size} code-referenced keys resolve `
+                + `(${direct.size} via $_(), ${indirect.size} via constants)`);
   }
 
+  const locales = fs.readdirSync(I18N_DIR).filter(f => f.endsWith('.json') && f !== SOURCE_FILE);
+  if (locales.length === 0) {
+    console.log('\n  No other locale files yet. Add fr.json / de.json / nl.json / etc. to src/i18n/.');
+  } else {
+    console.log('');
+    for (const file of locales.sort()) {
+      const langKeys = new Set(Object.keys(flatten(loadJson(file))));
+      const missing = [...enKeys].filter(k => !langKeys.has(k));
+      const orphaned = [...langKeys].filter(k => !enKeys.has(k));
+      const translated = enKeys.size - missing.length;
+      const pct = ((translated / enKeys.size) * 100).toFixed(0);
+      const status = missing.length === 0 && orphaned.length === 0 ? '✓' : 'i';
+      console.log(`  ${status} ${file.padEnd(10)} ${translated}/${enKeys.size}  ${pct.padStart(3)}%  ${missing.length} missing, ${orphaned.length} orphaned`);
+      if (missing.length > 0 && missing.length <= 10) for (const k of missing) console.log(`        missing: ${k}`);
+      else if (missing.length > 10) console.log(`        missing: ${missing.slice(0, 5).join(', ')} ... and ${missing.length - 5} more`);
+      if (orphaned.length > 0 && orphaned.length <= 5) for (const k of orphaned) console.log(`       orphaned: ${k}`);
+      else if (orphaned.length > 5) console.log(`       orphaned: ${orphaned.slice(0, 3).join(', ')} ... and ${orphaned.length - 3} more`);
+    }
+    console.log('\n  Incomplete translations are informational and do not fail this check.');
+  }
+
+  if (errors.length) {
+    console.log(`\n  FAILED: ${errors.join('; ')}\n`);
+    process.exit(1);
+  }
   console.log('');
-  process.exit(anyGap ? 1 : 0);
 }
 
 module.exports = { flatten, findDuplicateKeys, collectKeyRefs, IGNORED_INDIRECT };

--- a/scripts/i18n-check.test.js
+++ b/scripts/i18n-check.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import i18nCheck from '../scripts/i18n-check.cjs';
+
+const { findDuplicateKeys } = i18nCheck;
+
+test('findDuplicateKeys: sibling repeated blocks (the PR #33 bug)', () => {
+  assert.deepEqual(
+    findDuplicateKeys('{"login":{"a":1},"other":2,"login":{"b":3}}'),
+    ['login'],
+  );
+});
+
+test('findDuplicateKeys: nested duplicate reports a dotted path', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":{"x":1,"x":2}}'), ['a.x']);
+});
+
+test('findDuplicateKeys: same name at different depths is not a duplicate', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":{"t":1},"b":{"t":2}}'), []);
+});
+
+test('findDuplicateKeys: braces and colons inside values do not confuse it', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":"use {count}: now","b":2}'), []);
+});
+
+test('findDuplicateKeys: escaped quotes in a value', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":"said \\"hi\\"","a":2}'), ['a']);
+});
+
+test('findDuplicateKeys: escaped quotes in a key', () => {
+  assert.deepEqual(findDuplicateKeys('{"a\\"b":1,"a\\"b":2}'), ['a"b']);
+});
+
+test('findDuplicateKeys: arrays of objects', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":[{"x":1},{"x":2}],"b":[1,2]}'), []);
+});
+
+test('findDuplicateKeys: duplicate inside an array element', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":[{"x":1,"x":2}]}'), ['a[0].x']);
+});
+
+test('findDuplicateKeys: depth three', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":{"b":{"c":1,"c":2}}}'), ['a.b.c']);
+});
+
+test('findDuplicateKeys: escaped unicode in a value', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":"\\u00e1rbol","b":1}'), []);
+});
+
+test('findDuplicateKeys: empty object and empty array', () => {
+  assert.deepEqual(findDuplicateKeys('{"a":{},"b":[],"c":1}'), []);
+});
+
+test('findDuplicateKeys: a triple duplicate reports twice', () => {
+  assert.deepEqual(findDuplicateKeys('{"k":1,"k":2,"k":3}'), ['k', 'k']);
+});

--- a/scripts/i18n-check.test.js
+++ b/scripts/i18n-check.test.js
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import i18nCheck from '../scripts/i18n-check.cjs';
 
-const { findDuplicateKeys } = i18nCheck;
+const { findDuplicateKeys, collectKeyRefs, IGNORED_INDIRECT } = i18nCheck;
 
 test('findDuplicateKeys: sibling repeated blocks (the PR #33 bug)', () => {
   assert.deepEqual(
@@ -53,4 +56,56 @@ test('findDuplicateKeys: empty object and empty array', () => {
 
 test('findDuplicateKeys: a triple duplicate reports twice', () => {
   assert.deepEqual(findDuplicateKeys('{"k":1,"k":2,"k":3}'), ['k', 'k']);
+});
+
+function fixture(name, contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'i18n-check-'));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, contents);
+  return file;
+}
+
+test('collectKeyRefs: finds literal keys in $_() calls', () => {
+  const f = fixture('A.svelte', `<h1>{$_('login.title')}</h1>\n<p>{$_("common.back")}</p>`);
+  const { direct } = collectKeyRefs(new Set(['login', 'common']), [f]);
+  assert.deepEqual([...direct.keys()].sort(), ['common.back', 'login.title']);
+});
+
+test('collectKeyRefs: reports the line of each reference', () => {
+  const f = fixture('B.svelte', `line one\n{$_('login.title')}\n`);
+  const { direct } = collectKeyRefs(new Set(['login']), [f]);
+  assert.equal(direct.get('login.title').line, 2);
+});
+
+test('collectKeyRefs: finds key-shaped literals held in constants', () => {
+  const f = fixture('C.svelte', `const META = { workout: { titleKey: 'settings_workout.title' } };`);
+  const { direct, indirect } = collectKeyRefs(new Set(['settings_workout']), [f]);
+  assert.equal(direct.size, 0);
+  assert.deepEqual([...indirect.keys()], ['settings_workout.title']);
+});
+
+test('collectKeyRefs: ignores dotted strings whose root is not a top-level key', () => {
+  const f = fixture('D.svelte', `const cls = 'material.symbols.rounded';\nconst v = 'foo.bar';`);
+  const { indirect } = collectKeyRefs(new Set(['login']), [f]);
+  assert.equal(indirect.size, 0);
+});
+
+test('collectKeyRefs: honours the ignore list for indirect literals', () => {
+  assert.ok(IGNORED_INDIRECT.has('programs.id'));
+  const f = fixture('E.js', `const schema = { properties: { 'programs.id': {} } };`);
+  const { indirect } = collectKeyRefs(new Set(['programs']), [f]);
+  assert.equal(indirect.size, 0);
+});
+
+test('collectKeyRefs: the ignore list does not silence a real $_() call', () => {
+  const f = fixture('F.svelte', `{$_('programs.id')}`);
+  const { direct } = collectKeyRefs(new Set(['programs']), [f]);
+  assert.deepEqual([...direct.keys()], ['programs.id']);
+});
+
+test('collectKeyRefs: a key seen in $_() is not also reported as indirect', () => {
+  const f = fixture('G.svelte', `{$_('login.title')}\nconst k = 'login.title';`);
+  const { direct, indirect } = collectKeyRefs(new Set(['login']), [f]);
+  assert.equal(direct.size, 1);
+  assert.equal(indirect.size, 0);
 });


### PR DESCRIPTION
Thanks for applying #33 by hand and for saying what would have caught it. This is that follow-up, with the two checks you asked for.

`scripts/i18n-check.cjs` now does three things:

1. **Duplicate keys in `en.json`, at any depth.** `JSON.parse` keeps the last
   occurrence of a repeated key and drops the earlier ones silently, which is
   exactly how the duplicated `login` / `profile` sections made whole blocks of
   copy render as raw keys. After parsing, the evidence is gone, so this walks
   the raw text with a small recursive-descent scanner. Reproducing the #33 bug
   on this branch gives:

   ```
   ✗ duplicate keys in en.json — JSON.parse silently keeps the last one:
         login
   FAILED: 1 duplicate key(s) in en.json
   ```

2. **Code-referenced keys that don't resolve.** 1057 keys via `$_('...')`, plus
   12 key-shaped literals held in constants, which is how the Settings sidebar
   labels (`SECTION_META[...].titleKey`) and the Wizard's appearance options
   reach `$_()`. Those are the sidebar labels you checked by hand. A literal
   counts as a key only when its first segment is a top-level `en.json` key, so
   class names and other dotted strings stay out. Unresolved keys are reported
   with file and line, which is what pointing `SECTION_META` at a missing
   section looks like:

   ```
   ✗ keys referenced in code but absent from en.json:
         settings.noexisteseccion.appearance.section  (src/routes/Settings.svelte:397)
   ```

3. The existing locale comparison, unchanged in output.

**Exit codes are now split**, and that is the one part worth your attention.
Duplicates and unresolved keys exit 1. Missing or orphaned keys in another
locale report and exit 0. Nothing changes in this repo today, since `en.json`
is the only locale file, but it is what lets the script work as a CI gate
across the three apps: as the rules stand, `npm run i18n:check` exits 1 in both
NutriTrace (`fr.json`, 442 of 1688 keys) and CookTrace (`sv.json`, 442 of
1223), because any untranslated key fails. CONTRIBUTING tells translators there
is no urgency, so a red build for a half-finished locale would discourage
exactly what it asks for. If you'd rather keep partial translations failing,
say so and I'll put it behind a `--strict` flag in this PR.

**One exception in the reference scan.** `programs.id` in `src/lib/aiTools.js`
is a JSON-schema property path for an AI tool, not a translation key. It sits
in an explicit ignore list with the reason written next to it. The exception
applies to the indirect scan only, so a real `$_('programs.id')` would still be
caught.

This also adds `.github/workflows/ci.yml`, since there was no workflow for
checks and neither `npm test` nor `npm run i18n:check` ran automatically. Node
20, to match the Dockerfile. `docker.yml` is untouched, so image pushes are
unaffected.

The workflow deliberately does not run `npm run build`. A compile check would
catch Svelte errors on every PR and it is three more lines, but you asked for
the i18n check specifically and I'd rather not widen a PR you didn't ask to
widen. Happy to add those three lines here if you want them.

19 tests cover the cases a text scanner is easy to get wrong: values containing
braces and colons, escaped quotes in keys and values, arrays, the same key name
at different depths, and the sibling-duplicate shape from #33.

No strings changed, `en.json` untouched, no new dependencies. The two checks
assume only `src/i18n/en.json` plus `src/**/*.{svelte,js}`, so they are a
drop-in for NutriTrace and CookTrace if you ever want them there.

One last thing, unrelated to the check but noticed while writing it: some
visible text doesn't go through `$_()`, where CONTRIBUTING says the client-side
string surface was fully extracted as of v1.1.0. The tab labels in
`src/routes/Statistics.svelte:26-33`, all of
`src/components/diary/GymTools.svelte` (it never imports `_`), the weight
placeholders in `src/routes/WorkoutEditor.svelte:843,972`, and most
`confirmDialog()` titles and messages (for example
`src/routes/ProgramDetail.svelte:138`). This check won't catch that class of
thing: it verifies referenced keys that don't resolve, not literals that should
have been keys. Flagging it in case it saves you finding them one at a time.
