### PR TITLE
fix(stats): show all body measurements in the All range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to LiftTrace are documented here.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **The All range on Statistics no longer hides body measurements taken before your first workout.** The body-weight chart bounded its query by the earliest `workout_log` date, which is the right bound for volume, frequency, progress and records but not for weigh-ins: those are independent of whether you trained that day. Anyone who imported a weight history from another app, or weighed in during a break from training, silently lost those points with no way to see them from the UI. The All range now starts from the same `2000-01-01` floor the code already falls back to when there are no workouts.
+
+---
+
 ## v1.1.1 — 2026-08-04
 
 ### Changed

--- a/src/routes/Statistics.svelte
+++ b/src/routes/Statistics.svelte
@@ -191,9 +191,13 @@
 
   async function loadBodyWeights() {
     try {
-      // startDate / endDate are already reactive and handle the "All" case
-      // by resolving to earliestWorkoutDate.
-      const rows = await LtApi.getBodyStatsRange(startDate, endDate);
+      // Body stats are independent of workout history: someone can weigh in
+      // during a break, or import years of weigh-ins from another app before
+      // logging their first session here. Bounding "All" by the first workout
+      // date silently hides those, so this range starts from the epoch floor
+      // that startDate already falls back to when there are no workouts.
+      const from = range === 'All' ? '2000-01-01' : startDate;
+      const rows = await LtApi.getBodyStatsRange(from, endDate);
       bodyWeights = (rows || [])
         .map(r => ({ date: r.date, weight: parseFloat(r.stats?.weight) }))
         .filter(p => Number.isFinite(p.weight))


### PR DESCRIPTION
Small one, found while looking at the body-weight chart.

With the **All** range selected, the chart starts at your first logged workout
instead of your first weigh-in. `loadBodyWeights()` inherits `startDate`, which
for "All" resolves to `MIN(date) FROM workout_log`. That is the right bound for
volume, frequency, progress and records, since all of those describe workouts,
but weigh-ins are independent of whether you trained that day.

Every weigh-in recorded before that first workout is dropped from the chart,
with nothing in the UI to hint that the range is cutting anything. It shows up
whenever someone imports a weight history from another app (MyFitnessPal,
Strong, a spreadsheet) that goes further back than their LiftTrace training
history, and whenever someone kept weighing in through a break from training.
I hit it on my own instance, with years of imported weigh-ins simply absent
from All.

The fix is one line in `loadBodyWeights()`. `startDate` is deliberately left
alone, since the other tabs share it and bounding by the first workout is
correct for them, and the "All" case reuses the `'2000-01-01'` floor already in
that file rather than introducing another constant. As a side effect the chart
no longer waits on the `earliest-workout-date` request having landed, which was
a small race on first paint.

If you'd rather add a `GET /api/stats/earliest-body-stat-date` and bound it
properly instead of using the floor, the change is contained and I can do it in
review, whichever you prefer.

One note on the changelog: CONTRIBUTING asks for an entry under the unreleased
section, and there wasn't one, since past entries look like they get written
when you cut a release. I created it rather than skip the rule. Happy to drop
that commit if the release-time flow is what you want to keep.
