### PR TITLE
fix(i18n): route GymTools and WorkoutEditor strings through $_()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to LiftTrace are documented here.
 
 - **Weight placeholders in the workout editor and the plate calculator now follow the kg/lb setting from Settings → Units.** Both inputs hard-coded pound examples in their placeholder text regardless of that preference: the workout editor's weight target field always showed `e.g. 135`, and the plate calculator's target weight always showed `e.g. 225`. Switching to kg now shows `e.g. 60` and `e.g. 100` instead; only the example text changes, not the input itself.
 
+- **The rest field in the workout editor now reads `REST (s)` instead of `REST (S)`.** Field labels are uppercased by CSS, which also uppercased the unit: `S` is the symbol for siemens, while seconds is a lowercase `s`. The unit now sits in its own span that opts out of the transform.
+
 ---
 
 ## v1.1.1 — 2026-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to LiftTrace are documented here.
 
 - **The All range on Statistics no longer hides body measurements taken before your first workout.** The body-weight chart bounded its query by the earliest `workout_log` date, which is the right bound for volume, frequency, progress and records but not for weigh-ins: those are independent of whether you trained that day. Anyone who imported a weight history from another app, or weighed in during a break from training, silently lost those points with no way to see them from the UI. The All range now starts from the same `2000-01-01` floor the code already falls back to when there are no workouts.
 
+- **Weight placeholders in the workout editor and the plate calculator now follow the kg/lb setting from Settings → Units.** Both inputs hard-coded pound examples in their placeholder text regardless of that preference: the workout editor's weight target field always showed `e.g. 135`, and the plate calculator's target weight always showed `e.g. 225`. Switching to kg now shows `e.g. 60` and `e.g. 100` instead; only the example text changes, not the input itself.
+
 ---
 
 ## v1.1.1 — 2026-08-04

--- a/src/components/diary/GymTools.svelte
+++ b/src/components/diary/GymTools.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { _ } from 'svelte-i18n';
   import { portal } from '../../lib/portal.js';
   import { weightUnit } from '../../stores/settings.js';
 
@@ -70,28 +71,29 @@
     <div class="gt-sheet" on:click|stopPropagation on:keydown={() => {}}>
       <div class="sheet-handle"></div>
       <button class="gt-close-btn" on:click={() => open = false}
-              aria-label="Close" title="Close">
+              aria-label={$_('common.close')} title={$_('common.close')}>
         <span class="material-symbols-rounded">close</span>
       </button>
       <div class="gt-tabs">
         <button class="gt-tab" class:active={tab === 'plates'} on:click={() => tab = 'plates'}>
-          <span class="material-symbols-rounded" style="font-size:18px">fitness_center</span> Plates
+          <span class="material-symbols-rounded" style="font-size:18px">fitness_center</span> {$_('gym_tools.plates')}
         </button>
         <button class="gt-tab" class:active={tab === 'convert'} on:click={() => tab = 'convert'}>
-          <span class="material-symbols-rounded" style="font-size:18px">swap_horiz</span> Convert
+          <span class="material-symbols-rounded" style="font-size:18px">swap_horiz</span> {$_('gym_tools.convert')}
         </button>
       </div>
 
       {#if tab === 'plates'}
         <div class="gt-body">
           <div class="gt-input-row">
-            <label class="form-label">Target weight ({$weightUnit})</label>
-            <input class="input" type="number" step="0.5" bind:value={targetWeight} placeholder="e.g. 225" />
+            <label class="form-label">{$_('gym_tools.target_weight', { values: { unit: $weightUnit } })}</label>
+            <input class="input" type="number" step="0.5" bind:value={targetWeight}
+                   placeholder={$weightUnit === 'kg' ? $_('gym_tools.weight_ph_kg') : $_('gym_tools.weight_ph_lb')} />
           </div>
-          <div class="gt-bar-info">Bar: {barWeight} {$weightUnit}</div>
+          <div class="gt-bar-info">{$_('gym_tools.bar', { values: { weight: barWeight, unit: $weightUnit } })}</div>
 
           {#if perSide.length > 0}
-            <div class="gt-result-label">Each side:</div>
+            <div class="gt-result-label">{$_('gym_tools.each_side')}</div>
             <div class="gt-plates-visual">
               <div class="gt-bar-end"></div>
               {#each perSide as plate}
@@ -109,10 +111,10 @@
               {/each}
             </div>
             {#if remainder > 0.01}
-              <div class="gt-remainder">⚠️ {remainder} {$weightUnit} can't be loaded with available plates</div>
+              <div class="gt-remainder">⚠️ {$_('gym_tools.remainder', { values: { weight: remainder, unit: $weightUnit } })}</div>
             {/if}
           {:else if targetWeight}
-            <div class="gt-empty">Weight equals or is less than the bar ({barWeight} {$weightUnit})</div>
+            <div class="gt-empty">{$_('gym_tools.under_bar', { values: { weight: barWeight, unit: $weightUnit } })}</div>
           {/if}
         </div>
 
@@ -120,13 +122,13 @@
         <div class="gt-body">
           <div class="gt-convert-row">
             <select class="gt-convert-select" bind:value={convertDir}>
-              <option value="lbs_to_kg">lbs → kg</option>
-              <option value="kg_to_lbs">kg → lbs</option>
+              <option value="lbs_to_kg">{$_('gym_tools.lbs_to_kg')}</option>
+              <option value="kg_to_lbs">{$_('gym_tools.kg_to_lbs')}</option>
             </select>
           </div>
           <div class="gt-input-row">
-            <label class="form-label">{convertDir === 'lbs_to_kg' ? 'Pounds (lbs)' : 'Kilograms (kg)'}</label>
-            <input class="input" type="number" step="0.1" bind:value={convertInput} placeholder="Enter weight" />
+            <label class="form-label">{convertDir === 'lbs_to_kg' ? $_('gym_tools.pounds') : $_('gym_tools.kilograms')}</label>
+            <input class="input" type="number" step="0.1" bind:value={convertInput} placeholder={$_('gym_tools.weight_ph')} />
           </div>
           {#if convertInput}
             <div class="gt-convert-result">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -438,7 +438,10 @@
     "add_to_superset":       "Add to Superset",
     "create_superset":       "Create Superset",
     "create_hint":           "Select exercises to group with {name}:",
-    "merge_into_superset":   "Merge Into Superset"
+    "merge_into_superset":   "Merge Into Superset",
+    "join_hint":             "Choose which superset to join:",
+    "create_confirm":        "Create Superset ({count} exercises)",
+    "merge_hint":            "All exercises from both supersets will be combined:"
   },
   "time_picker": {
     "hour":                  "Hour",
@@ -792,7 +795,29 @@
     "reps":                "Reps",
     "weight":              "Weight",
     "tempo":               "Tempo",
-    "notes_ph":            "Notes..."
+    "notes_ph":            "Notes...",
+    "week":                 "Week {n}",
+    "copy_week":            "Copy Week {from} into Week {to}",
+    "week_matches":         "Week {to} already matches Week {from}",
+    "copy_week_aria":       "Copy this week into the next week",
+    "ex_count":             "{count} exercises",
+    "load_bilateral":       "Bilateral",
+    "load_paired":          "Per side",
+    "load_unilateral":      "Alternating",
+    "load_hint_bilateral":  "single load — barbell, machine, both arms move one thing",
+    "load_hint_paired":     "both arms work together with separate equal loads",
+    "load_hint_unilateral": "one side at a time",
+    "copy_ex_week":         "Copy this exercise's Week {from} into Week {to}",
+    "copy_ex_week_aria":    "Copy this exercise into Week {to}",
+    "add_set":              "Add set",
+    "reps_ph":              "e.g. 8-12",
+    "weight_ph_lb":         "e.g. 135",
+    "weight_ph_kg":         "e.g. 60",
+    "tempo_ph":             "e.g. 3.1.1",
+    "rest":                 "Rest (s)",
+    "rest_ph":              "e.g. 90",
+    "per_set_link":         "Different weight or reps per set…",
+    "add_exercise":         "Add Exercise"
   },
   "statistics": {
     "day_streak":        "Day Streak",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -823,6 +823,22 @@
     "choose_exercise":   "Choose Exercise",
     "search_exercises_ph": "Search exercises…"
   },
+  "gym_tools": {
+    "plates":          "Plates",
+    "convert":         "Convert",
+    "target_weight":   "Target weight ({unit})",
+    "weight_ph_lb":    "e.g. 225",
+    "weight_ph_kg":    "e.g. 100",
+    "bar":             "Bar: {weight} {unit}",
+    "each_side":       "Each side:",
+    "remainder":       "{weight} {unit} can't be loaded with available plates",
+    "under_bar":       "Weight equals or is less than the bar ({weight} {unit})",
+    "lbs_to_kg":       "lbs → kg",
+    "kg_to_lbs":       "kg → lbs",
+    "pounds":          "Pounds (lbs)",
+    "kilograms":       "Kilograms (kg)",
+    "weight_ph":       "Enter weight"
+  },
   "coaching": {
     "toast": {
       "released":              "{name} released from your roster",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -814,7 +814,7 @@
     "weight_ph_lb":         "e.g. 135",
     "weight_ph_kg":         "e.g. 60",
     "tempo_ph":             "e.g. 3.1.1",
-    "rest":                 "Rest (s)",
+    "rest":                 "Rest",
     "rest_ph":              "e.g. 90",
     "per_set_link":         "Different weight or reps per set…",
     "add_exercise":         "Add Exercise"

--- a/src/routes/WorkoutEditor.svelte
+++ b/src/routes/WorkoutEditor.svelte
@@ -853,7 +853,7 @@
                             <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder={$_('workout_editor.tempo_ph')} />
                           </div>
                           <div class="field">
-                            <label>{$_('workout_editor.rest')}</label>
+                            <label>{$_('workout_editor.rest')} <span class="unit">(s)</span></label>
                             <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder={$_('workout_editor.rest_ph')} />
                           </div>
                         </div>
@@ -984,7 +984,7 @@
                     <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder={$_('workout_editor.tempo_ph')} />
                   </div>
                   <div class="field">
-                    <label>{$_('workout_editor.rest')}</label>
+                    <label>{$_('workout_editor.rest')} <span class="unit">(s)</span></label>
                     <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder={$_('workout_editor.rest_ph')} />
                   </div>
                 </div>
@@ -1249,6 +1249,8 @@
   .week-copy-arrow:disabled { color: var(--text-3); opacity: 0.4; cursor: default; }
   .week-copy-arrow .material-symbols-rounded { font-size: 20px; }
   .field label { display: block; font-size: 11px; color: var(--text-3); margin-bottom: 3px; font-weight: 600; text-transform: uppercase; }
+  /* Unit symbols must not be uppercased: "s" is seconds, "S" is siemens. */
+  .field label .unit { text-transform: none; }
   .field input {
     width: 100%; background: var(--surface-2); border: 1px solid var(--border);
     border-radius: var(--radius-sm); padding: 7px 8px; color: var(--text-1);

--- a/src/routes/WorkoutEditor.svelte
+++ b/src/routes/WorkoutEditor.svelte
@@ -4,7 +4,7 @@
   import { _ } from 'svelte-i18n';
   import { LtApi } from '../lib/api.js';
   import { showSuccess, showError } from '../stores/toast.js';
-  import { exerciseLoadTypes, trackRpe } from '../stores/settings.js';
+  import { exerciseLoadTypes, trackRpe, weightUnit } from '../stores/settings.js';
   import { resolveLoadType } from '../lib/workout.js';
   import TemplateSpecRow from '../components/programs/TemplateSpecRow.svelte';
   import ExercisePicker from '../components/exercises/ExercisePicker.svelte';
@@ -697,15 +697,17 @@
              The copy arrow sits between the active week and the next, and is
              only enabled when the current week actually differs from next. -->
         <div class="week-strip">
-          {#each Array(durationWeeks) as _, i}
+          {#each Array(durationWeeks) as _w, i}
             <button class="week-tab" class:active={activeWeek === i + 1} on:click={() => activeWeek = i + 1}>
-              Week {i + 1}
+              {$_('workout_editor.week', { values: { n: i + 1 } })}
             </button>
             {#if activeWeek === i + 1 && i + 1 < durationWeeks}
               <button class="week-copy-arrow" disabled={!canCopyWeek}
                 on:click={copyWeekToNext}
-                title={canCopyWeek ? `Copy Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
-                aria-label="Copy this week into the next week">
+                title={canCopyWeek
+                  ? $_('workout_editor.copy_week', { values: { from: activeWeek, to: activeWeek + 1 } })
+                  : $_('workout_editor.week_matches', { values: { from: activeWeek, to: activeWeek + 1 } })}
+                aria-label={$_('workout_editor.copy_week_aria')}>
                 <span class="material-symbols-rounded">arrow_forward</span>
               </button>
             {/if}
@@ -725,7 +727,7 @@
               <div class="ss-header">
                 <span class="material-symbols-rounded ss-icon">link</span>
                 <span class="ss-label">{$_('workout_editor.superset')}</span>
-                <span class="ss-count">{group.exercises.length} exercises</span>
+                <span class="ss-count">{$_('workout_editor.ex_count', { values: { count: group.exercises.length } })}</span>
                 <button class="btn-icon-xs ss-menu" on:click={() => openSsActions(group.id)} title={$_('workout_editor.ss_options')}>
                   <span class="material-symbols-rounded">more_horiz</span>
                 </button>
@@ -763,8 +765,8 @@
                           <button type="button" class="load-chip" class:non-default={lt !== 'bilateral'}
                                   on:click|stopPropagation={() => loadMenuIdx = (loadMenuIdx === idx ? null : idx)}
                                   title={$_('workout_editor.load_type')}>
-                            {#if lt === 'paired'}<span class="material-symbols-rounded">compare_arrows</span>Per side
-                            {:else if lt === 'unilateral'}<span class="material-symbols-rounded">swap_horiz</span>Alternating
+                            {#if lt === 'paired'}<span class="material-symbols-rounded">compare_arrows</span>{$_('workout_editor.load_paired')}
+                            {:else if lt === 'unilateral'}<span class="material-symbols-rounded">swap_horiz</span>{$_('workout_editor.load_unilateral')}
                             {:else}<span class="material-symbols-rounded">straighten</span>{/if}
                           </button>
                         {/each}
@@ -774,8 +776,10 @@
                         {#if durationWeeks > 1 && activeWeek < durationWeeks}
                           <button type="button" class="ex-week-copy" disabled={!weekDiffersFromNext(ex, activeWeek, durationWeeks)}
                             on:click|stopPropagation={() => copyExerciseWeekToNext(idx)}
-                            title={weekDiffersFromNext(ex, activeWeek, durationWeeks) ? `Copy this exercise's Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
-                            aria-label="Copy this exercise into Week {activeWeek + 1}">
+                            title={weekDiffersFromNext(ex, activeWeek, durationWeeks)
+                              ? $_('workout_editor.copy_ex_week', { values: { from: activeWeek, to: activeWeek + 1 } })
+                              : $_('workout_editor.week_matches', { values: { from: activeWeek, to: activeWeek + 1 } })}
+                            aria-label={$_('workout_editor.copy_ex_week_aria', { values: { to: activeWeek + 1 } })}>
                             <span class="material-symbols-rounded">arrow_forward</span>{activeWeek + 1}
                           </button>
                         {/if}
@@ -789,14 +793,14 @@
                         <div class="load-menu-backdrop" on:click|stopPropagation={() => loadMenuIdx = null}></div>
                         <div class="load-menu" on:click|stopPropagation>
                           <div class="load-menu-head">{$_('workout_editor.load_type')}</div>
-                          {#each [['bilateral','Bilateral','single load — barbell, machine, both arms move one thing'],
-                                  ['paired','Per side','both arms work together with separate equal loads'],
-                                  ['unilateral','Alternating','one side at a time']] as [val, label, hint]}
+                          {#each [['bilateral','workout_editor.load_bilateral','workout_editor.load_hint_bilateral'],
+                                  ['paired','workout_editor.load_paired','workout_editor.load_hint_paired'],
+                                  ['unilateral','workout_editor.load_unilateral','workout_editor.load_hint_unilateral']] as [val, labelKey, hintKey]}
                             <button class="load-menu-item" class:active={exLoadType(ex) === val} type="button"
                                     on:click={() => pickLoadType(idx, val)}>
                               <div class="lm-text">
-                                <span class="lm-label">{label}</span>
-                                <span class="lm-hint">{hint}</span>
+                                <span class="lm-label">{$_(labelKey)}</span>
+                                <span class="lm-hint">{$_(hintKey)}</span>
                               </div>
                               {#if exLoadType(ex) === val}<span class="material-symbols-rounded lm-check">check</span>{/if}
                             </button>
@@ -823,7 +827,7 @@
                           {/each}
                           <div class="per-set-actions">
                             <button class="per-set-add" on:click={() => addSpecSet(idx)}>
-                              <span class="material-symbols-rounded">add</span> Add set
+                              <span class="material-symbols-rounded">add</span> {$_('workout_editor.add_set')}
                             </button>
                             <button class="per-set-link" on:click={() => disablePerSet(idx)}>{$_('workout_editor.use_uniform')}</button>
                           </div>
@@ -836,26 +840,26 @@
                           </div>
                           <div class="field">
                             <label>{$_('workout_editor.reps')}</label>
-                            <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder="e.g. 8-12" />
+                            <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder={$_('workout_editor.reps_ph')} />
                           </div>
                           <div class="field">
                             <label>{$_('workout_editor.weight')}</label>
-                            <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder="e.g. 135" />
+                            <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder={$weightUnit === 'kg' ? $_('workout_editor.weight_ph_kg') : $_('workout_editor.weight_ph_lb')} />
                           </div>
                         </div>
                         <div class="ex-fields two-col">
                           <div class="field">
                             <label>{$_('workout_editor.tempo')}</label>
-                            <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder="e.g. 3.1.1" />
+                            <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder={$_('workout_editor.tempo_ph')} />
                           </div>
                           <div class="field">
-                            <label>Rest (s)</label>
-                            <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder="e.g. 90" />
+                            <label>{$_('workout_editor.rest')}</label>
+                            <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder={$_('workout_editor.rest_ph')} />
                           </div>
                         </div>
                         <button class="per-set-link" on:click={() => enablePerSet(idx)}>
                           <span class="material-symbols-rounded" style="font-size:14px">tune</span>
-                          Different weight or reps per set…
+                          {$_('workout_editor.per_set_link')}
                         </button>
                       {/if}
                       <input class="notes-input" type="text" value={ex.notes || ''} on:input={e => updateExercise(idx, 'notes', e.target.value)} placeholder={$_('workout_editor.notes_ph')} />
@@ -892,8 +896,8 @@
                   <button type="button" class="load-chip" class:non-default={lt !== 'bilateral'}
                           on:click|stopPropagation={() => loadMenuIdx = (loadMenuIdx === idx ? null : idx)}
                           title={$_('workout_editor.load_type')}>
-                    {#if lt === 'paired'}<span class="material-symbols-rounded">compare_arrows</span>Per side
-                    {:else if lt === 'unilateral'}<span class="material-symbols-rounded">swap_horiz</span>Alternating
+                    {#if lt === 'paired'}<span class="material-symbols-rounded">compare_arrows</span>{$_('workout_editor.load_paired')}
+                    {:else if lt === 'unilateral'}<span class="material-symbols-rounded">swap_horiz</span>{$_('workout_editor.load_unilateral')}
                     {:else}<span class="material-symbols-rounded">straighten</span>{/if}
                   </button>
                 {/each}
@@ -903,8 +907,10 @@
                 {#if durationWeeks > 1 && activeWeek < durationWeeks}
                   <button type="button" class="ex-week-copy" disabled={!weekDiffersFromNext(ex, activeWeek, durationWeeks)}
                     on:click|stopPropagation={() => copyExerciseWeekToNext(idx)}
-                    title={weekDiffersFromNext(ex, activeWeek, durationWeeks) ? `Copy this exercise's Week ${activeWeek} into Week ${activeWeek + 1}` : `Week ${activeWeek + 1} already matches Week ${activeWeek}`}
-                    aria-label="Copy this exercise into Week {activeWeek + 1}">
+                    title={weekDiffersFromNext(ex, activeWeek, durationWeeks)
+                      ? $_('workout_editor.copy_ex_week', { values: { from: activeWeek, to: activeWeek + 1 } })
+                      : $_('workout_editor.week_matches', { values: { from: activeWeek, to: activeWeek + 1 } })}
+                    aria-label={$_('workout_editor.copy_ex_week_aria', { values: { to: activeWeek + 1 } })}>
                     <span class="material-symbols-rounded">arrow_forward</span>{activeWeek + 1}
                   </button>
                 {/if}
@@ -918,14 +924,14 @@
                 <div class="load-menu-backdrop" on:click|stopPropagation={() => loadMenuIdx = null}></div>
                 <div class="load-menu" on:click|stopPropagation>
                   <div class="load-menu-head">{$_('workout_editor.load_type')}</div>
-                  {#each [['bilateral','Bilateral','single load — barbell, machine, both arms move one thing'],
-                          ['paired','Per side','both arms work together with separate equal loads'],
-                          ['unilateral','Alternating','one side at a time']] as [val, label, hint]}
+                  {#each [['bilateral','workout_editor.load_bilateral','workout_editor.load_hint_bilateral'],
+                          ['paired','workout_editor.load_paired','workout_editor.load_hint_paired'],
+                          ['unilateral','workout_editor.load_unilateral','workout_editor.load_hint_unilateral']] as [val, labelKey, hintKey]}
                     <button class="load-menu-item" class:active={exLoadType(ex) === val} type="button"
                             on:click={() => pickLoadType(idx, val)}>
                       <div class="lm-text">
-                        <span class="lm-label">{label}</span>
-                        <span class="lm-hint">{hint}</span>
+                        <span class="lm-label">{$_(labelKey)}</span>
+                        <span class="lm-hint">{$_(hintKey)}</span>
                       </div>
                       {#if exLoadType(ex) === val}<span class="material-symbols-rounded lm-check">check</span>{/if}
                     </button>
@@ -952,7 +958,7 @@
                   {/each}
                   <div class="per-set-actions">
                     <button class="per-set-add" on:click={() => addSpecSet(idx)}>
-                      <span class="material-symbols-rounded">add</span> Add set
+                      <span class="material-symbols-rounded">add</span> {$_('workout_editor.add_set')}
                     </button>
                     <button class="per-set-link" on:click={() => disablePerSet(idx)}>{$_('workout_editor.use_uniform')}</button>
                   </div>
@@ -965,26 +971,26 @@
                   </div>
                   <div class="field">
                     <label>{$_('workout_editor.reps')}</label>
-                    <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder="e.g. 8-12" />
+                    <input type="text" value={weekVal(ex, 'reps', activeWeek)} on:input={e => setWeekVal(idx, 'reps', e.target.value)} placeholder={$_('workout_editor.reps_ph')} />
                   </div>
                   <div class="field">
                     <label>{$_('workout_editor.weight')}</label>
-                    <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder="e.g. 135" />
+                    <input type="text" value={weekVal(ex, 'weight', activeWeek)} on:input={e => setWeekVal(idx, 'weight', e.target.value)} placeholder={$weightUnit === 'kg' ? $_('workout_editor.weight_ph_kg') : $_('workout_editor.weight_ph_lb')} />
                   </div>
                 </div>
                 <div class="ex-fields two-col">
                   <div class="field">
                     <label>{$_('workout_editor.tempo')}</label>
-                    <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder="e.g. 3.1.1" />
+                    <input type="text" value={weekVal(ex, 'tempo', activeWeek)} on:input={e => setWeekVal(idx, 'tempo', e.target.value)} placeholder={$_('workout_editor.tempo_ph')} />
                   </div>
                   <div class="field">
-                    <label>Rest (s)</label>
-                    <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder="e.g. 90" />
+                    <label>{$_('workout_editor.rest')}</label>
+                    <input type="number" value={weekVal(ex, 'rest_sec', activeWeek)} on:input={e => setWeekVal(idx, 'rest_sec', parseInt(e.target.value))} placeholder={$_('workout_editor.rest_ph')} />
                   </div>
                 </div>
                 <button class="per-set-link" on:click={() => enablePerSet(idx)}>
                   <span class="material-symbols-rounded" style="font-size:14px">tune</span>
-                  Different weight or reps per set…
+                  {$_('workout_editor.per_set_link')}
                 </button>
               {/if}
               <input class="notes-input" type="text" value={ex.notes || ''} on:input={e => updateExercise(idx, 'notes', e.target.value)} placeholder={$_('workout_editor.notes_ph')} />
@@ -995,7 +1001,7 @@
 
       <button class="add-btn" on:click={() => { addingToSsId = null; showPicker = true; }}>
         <span class="material-symbols-rounded">add</span>
-        Add Exercise
+        {$_('workout_editor.add_exercise')}
       </button>
     </div>
   {/if}
@@ -1021,7 +1027,7 @@
 <!-- Superset action sheet -->
 <ActionSheet
   bind:open={ssAsOpen}
-  title="Superset Options"
+  title={$_('workout_editor.ss_options')}
   actions={ssAsActions}
   on:select={handleSsAction}
   on:cancel={() => ssAsOpen = false}
@@ -1032,7 +1038,7 @@
   <div class="ss-picker">
     {#if ssPickerMode === 'join'}
       <h3 class="picker-title">{$_('workout_editor_ss.add_to_superset')}</h3>
-      <p class="picker-hint">Choose which superset to join:</p>
+      <p class="picker-hint">{$_('workout_editor_ss.join_hint')}</p>
       {#each existingSupersets as ss}
         <button class="ss-option" on:click={() => handleJoinSuperset(ss.id)}>
           <span class="material-symbols-rounded" style="color:var(--accent)">link</span>
@@ -1058,7 +1064,7 @@
         {/each}
       </div>
       <button class="btn btn-primary pick-confirm" disabled={newSsPicks.length === 0} on:click={handleCreateSuperset}>
-        Create Superset ({newSsPicks.length + 1} exercises)
+        {$_('workout_editor_ss.create_confirm', { values: { count: newSsPicks.length + 1 } })}
       </button>
     {/if}
   </div>
@@ -1068,7 +1074,7 @@
 <Sheet open={ssMergePickerOpen} on:close={() => ssMergePickerOpen = false}>
   <div class="ss-picker">
     <h3 class="picker-title">{$_('workout_editor_ss.merge_into_superset')}</h3>
-    <p class="picker-hint">All exercises from both supersets will be combined:</p>
+    <p class="picker-hint">{$_('workout_editor_ss.merge_hint')}</p>
     {#each existingSupersets.filter(s => String(s.id) !== String(ssAsTargetId)) as ss}
       <button class="ss-option" on:click={() => handleMerge(ss.id)}>
         <span class="material-symbols-rounded" style="color:var(--accent)">merge</span>


### PR DESCRIPTION
Thanks for applying #35 by hand, and for the follow-up in `3fd16a5`. The filename literals were a real hole in what I sent (`foods.json` matched `KEYISH_RE` because `foods` is a top-level key), and a shape rule is the better fix: I would have reached for a per-string ignore list, which is exactly what breaks when the check moves to NutriTrace and CookTrace.

This is the separate PR you offered to take, for two of the surfaces. Every visible string in the markup of `GymTools.svelte` and `WorkoutEditor.svelte` now goes through `$_()`.

Two sets of literal in `WorkoutEditor.svelte` are still there and I left them deliberately: the ten ActionSheet labels in the exercise and superset menus (`234-248` and `338-343`) and `Spinner label="Loading template…"` at `692`. Both are patterns rather than oversights. Literal action labels are how the repo does it everywhere (`Diary.svelte:300`, `Exercises.svelte:313`, `ProgramDetail.svelte:264`), and that Spinner call is one of eight identical ones. The action labels would also put a decision on you: the sheet reads `Move up` while `workout_editor.move_up` already holds `Move Up`, so extracting them means either changing what users read or adding near-duplicate keys.

**It was bigger than what I flagged.** For the editor I only mentioned the weight placeholders. Reading the whole file, there were also the week tabs, the two copy-to-next-week buttons with their titles and aria-labels, the load-type chips and the menu behind them with its three hints, `Rest (s)` sitting two lines under a `$_()` call, `Add set`, `Add Exercise`, and the three hints in the superset sheets. 39 new keys: 14 in a new `gym_tools` section, 22 added to `workout_editor`, 3 to `workout_editor_ss`.

Two strings needed no key at all. `title="Superset Options"` already had `workout_editor.ss_options` holding exactly that text, and GymTools' close button now uses `common.close`.

The load-type menu kept its labels and hints inside a data array, where `$_()` cannot reach at module level, so the array now holds keys and resolves at render, the way `SECTION_META` does in `Settings.svelte`. That shape has a side benefit: `i18n:check` reads it as an indirect reference, so those six keys are verified by the check you just merged.

**One change is not an extraction.** The week tabs iterate with `{#each Array(durationWeeks) as _, i}`, and that `_` shadows the `svelte-i18n` store inside the block, so calling `$_()` there fails to compile with `store_invalid_scoped_subscription`. The loop item is never used in the body, so it is now `_w`. One word, no behaviour change, but it shows up in the diff and I would rather name it than have you wonder.

**Two things are user-visible, and both are easy to drop.** Everything else reproduces today's English exactly.

The first: both weight placeholders hard-coded pound examples regardless of the unit setting, so `e.g. 135` and `e.g. 225` read as nonsense in kg. They now pick between two keys on `$weightUnit`. To undo it, delete the two `weight_ph_kg` keys, the two ternaries and that CHANGELOG bullet.

The second came out of looking at the editor on screen. `.field label` has `text-transform: uppercase`, which was also uppercasing the unit: `Rest (s)` rendered as `REST (S)`, and capital `S` is siemens while seconds is a lowercase `s`. The `(s)` now sits in its own span that opts out of the transform, so the label reads `REST (s)`. That one is a commit of its own, so dropping the commit is enough.

Both changes have a CHANGELOG entry.

Three things in GymTools stay literals on purpose. The plate chip (`{count} × {plate} {$weightUnit}`) and the converter's result unit (`'kg'` / `'lbs'`) are unit symbols next to a number, and the app renders `$weightUnit` raw everywhere, so translating those two and nothing else would be the inconsistency. The warning emoji stays in the markup instead of inside the JSON value, so a translator gets the sentence and not the glyph.

Verified: `npm run i18n:check`, `npm test` (29/29) and `npm run build` all clean, every existing English string reproduced character for character, and the interpolation names checked against each call site, since a mismatch there is the one failure mode the check cannot see. One thing I ran rather than assumed: `copy_ex_week` puts an apostrophe before its placeholders (`Copy this exercise's Week {from} into Week {to}`) and ICU treats `'` as an escape character, so I formatted it against the installed `intl-messageformat` to be sure it interpolates. It does. formatjs only opens a quote when the apostrophe comes directly before `{`, `}`, `#` or `|`.

Statistics and the `confirmDialog` titles are coming as their own PRs, one each. They are both bigger than this one: Statistics adds about eighty keys to a single route, and `confirmDialog` covers the dialogs across eleven files, so folding either into this PR would have made it hard to review.

No hurry on the review, and no hard feelings if either of the two visible changes is not to your taste.
