### PR TITLE
fix(i18n): route confirmation dialogs through $_()

### DIFF
--- a/src/components/diary/CardioCard.svelte
+++ b/src/components/diary/CardioCard.svelte
@@ -9,6 +9,7 @@
   // hard line against device sync in LT.
 
   import { onMount } from 'svelte';
+  import { _ } from 'svelte-i18n';
   import { LtApi } from '../../lib/api.js';
   import { currentDate } from '../../stores/workout.js';
   import { weightUnit } from '../../stores/settings.js';
@@ -141,10 +142,10 @@
 
   async function remove(session) {
     const ok = await confirmDialog({
-      title: 'Delete cardio session?',
-      message: `${session.activity} · ${session.duration_min} min`,
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
+      title: $_('diary.confirm.delete_cardio_title'),
+      message: $_('diary.confirm.delete_cardio_msg', { values: { activity: session.activity, duration: session.duration_min } }),
+      confirmText: $_('common.delete'),
+      cancelText: $_('common.cancel'),
       dangerous: true,
     });
     if (!ok) return;

--- a/src/components/settings/SettingsCatalog.svelte
+++ b/src/components/settings/SettingsCatalog.svelte
@@ -64,9 +64,9 @@
 
   async function clearSource(src) {
     if (!await confirmDialog({
-      title: `Clear imported exercises?`,
-      message: `This removes all ${src.count} exercises imported from ${src.name}. The source stays listed so you can re-import at any time.`,
-      confirmText: 'Clear',
+      title: $_('settings_catalog.confirm.clear_imported_title'),
+      message: $_('settings_catalog.confirm.clear_imported_msg', { values: { count: src.count, name: src.name } }),
+      confirmText: $_('settings_catalog.confirm.clear_confirm'),
       dangerous: true,
     })) return;
     sourceBusy = { ...sourceBusy, [src.id]: 'clear' };
@@ -189,9 +189,9 @@
 
   async function removeCustom(ex) {
     if (!await confirmDialog({
-      title: `Delete "${ex.name}"?`,
-      message: 'Workout history keeps its record — only the library link breaks.',
-      confirmText: 'Delete', dangerous: true,
+      title: $_('settings_catalog.confirm.delete_named_title', { values: { name: ex.name } }),
+      message: $_('settings_catalog.confirm.delete_exercise_msg'),
+      confirmText: $_('common.delete'), dangerous: true,
     })) return;
     try {
       await LtApi.deleteExercise(ex.id);
@@ -203,9 +203,9 @@
   async function removeAllCustom() {
     if (customExercises.length === 0) return;
     if (!await confirmDialog({
-      title: `Delete all ${customExercises.length} custom exercises?`,
-      message: 'This cannot be undone. Workout history keeps its records — only library links break.',
-      confirmText: 'Delete all', dangerous: true,
+      title: $_('settings_catalog.confirm.delete_all_title', { values: { count: customExercises.length } }),
+      message: $_('settings_catalog.confirm.delete_all_msg'),
+      confirmText: $_('settings_catalog.confirm.delete_all_confirm'), dangerous: true,
     })) return;
     try {
       const r = await LtApi.deleteAllCustomExercises();
@@ -229,7 +229,7 @@
   }
 
   async function deleteCatalog(cat) {
-    if (!await confirmDialog({ title: `Delete "${cat.name}"?`, message: `All ${cat.count} exercises from this catalog will be removed.`, confirmText: 'Delete', dangerous: true })) return;
+    if (!await confirmDialog({ title: $_('settings_catalog.confirm.delete_named_title', { values: { name: cat.name } }), message: $_('settings_catalog.confirm.delete_catalog_msg', { values: { count: cat.count } }), confirmText: $_('common.delete'), dangerous: true })) return;
     try {
       await fetch('/api/exercise-import/catalogs/delete', {
         method: 'POST', credentials: 'include',

--- a/src/components/settings/SettingsWorkoutImport.svelte
+++ b/src/components/settings/SettingsWorkoutImport.svelte
@@ -83,10 +83,10 @@
     let onDuplicate = 'skip';
     if (importPreview.duplicateDates > 0) {
       const replace = await confirmDialog({
-        title: `${importPreview.duplicateDates} dates already have workouts`,
-        message: 'Skip the imported copies of those days, or replace your existing workouts with the imported ones?',
-        confirmText: 'Replace existing',
-        cancelText: 'Skip duplicates',
+        title: $_('settings_workout_import.confirm.duplicate_dates_title', { values: { count: importPreview.duplicateDates } }),
+        message: $_('settings_workout_import.confirm.duplicate_dates_msg'),
+        confirmText: $_('settings_workout_import.confirm.replace_existing'),
+        cancelText: $_('settings_workout_import.confirm.skip_duplicates'),
         dangerous: true,
       });
       onDuplicate = replace ? 'replace' : 'skip';

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -172,6 +172,22 @@
     "errors": {
       "no_workout_yesterday": "No workout found yesterday",
       "copy_failed":          "Failed to copy workout"
+    },
+    "confirm": {
+      "delete_cardio_title":     "Delete cardio session?",
+      "delete_cardio_msg":       "{activity} · {duration} min",
+      "delete_reply_title":      "Delete your reply?",
+      "delete_reply_msg":        "Your reply to this note will be removed.",
+      "replace_workout_title":   "Replace workout?",
+      "replace_confirm":         "Replace",
+      "replace_suggested_msg":   "Loading the suggested workout will overwrite your current workout for today.",
+      "replace_template_msg":    "Picking a new template will overwrite your current workout for today.",
+      "replace_prescribed_msg":  "Loading the prescribed workout will overwrite your current workout for today.",
+      "remove_exercise_title":   "Remove exercise?",
+      "remove_exercise_msg":     "{name} will be removed from today's workout.",
+      "remove_superset_title":   "Remove superset?",
+      "remove_superset_msg":     "{list} will be removed from today's workout.",
+      "remove_confirm":          "Remove"
     }
   },
   "trace": {
@@ -528,7 +544,11 @@
     "top_set_over_time":     "Top Set Over Time",
     "similar_exercises":     "Similar Exercises",
     "try_again":             "Try Again",
-    "back_to_exercises":     "Back to Exercises"
+    "back_to_exercises":     "Back to Exercises",
+    "confirm": {
+      "delete_title": "Delete \"{name}\"?",
+      "delete_msg":   "This removes the exercise from your library. Any workouts that logged it keep their history — only the link breaks."
+    }
   },
   "settings_federation": {
     "url_token_required":    "Enter a URL and access token first",
@@ -570,7 +590,13 @@
     "how_to_export":         "How to Export",
     "import_another_file":   "Import Another File",
     "ready_to_import":       "Ready to Import",
-    "cancel":                "Cancel"
+    "cancel":                "Cancel",
+    "confirm": {
+      "duplicate_dates_title": "{count} dates already have workouts",
+      "duplicate_dates_msg":   "Skip the imported copies of those days, or replace your existing workouts with the imported ones?",
+      "replace_existing":      "Replace existing",
+      "skip_duplicates":       "Skip duplicates"
+    }
   },
   "settings_statistics": {
     "default_chart_type":    "Default Chart Type",
@@ -592,7 +618,18 @@
     "catalog_name":          "Catalog Name",
     "json":                  "JSON",
     "json_ph":               "Paste JSON here, or pick a .json file below",
-    "imported_catalogs":     "Imported Catalogs"
+    "imported_catalogs":     "Imported Catalogs",
+    "confirm": {
+      "clear_imported_title": "Clear imported exercises?",
+      "clear_imported_msg":   "This removes all {count} exercises imported from {name}. The source stays listed so you can re-import at any time.",
+      "clear_confirm":        "Clear",
+      "delete_named_title":   "Delete \"{name}\"?",
+      "delete_exercise_msg":  "Workout history keeps its record — only the library link breaks.",
+      "delete_all_title":     "Delete all {count} custom exercises?",
+      "delete_all_msg":       "This cannot be undone. Workout history keeps its records — only library links break.",
+      "delete_all_confirm":   "Delete all",
+      "delete_catalog_msg":   "All {count} exercises from this catalog will be removed."
+    }
   },
   "settings_radio": {
     "streaming_stations":    "Streaming Stations",
@@ -644,7 +681,13 @@
     "option_hold":           "Hold on the Final Week",
     "cancel":                "Cancel",
     "new_workout":           "New Workout",
-    "name":                  "Name"
+    "name":                  "Name",
+    "confirm": {
+      "delete_workout_title": "Delete workout?",
+      "delete_workout_msg":   "This removes the workout template from this program.",
+      "delete_program_title": "Delete program?",
+      "delete_program_msg":   "Deletes the entire program and all of its workouts. This cannot be undone."
+    }
   },
   "exercise_editor": {
     "toast": {
@@ -765,7 +808,11 @@
     "group":                   "Group",
     "icon_url":                "Icon URL",
     "new_name":                "New Name",
-    "leave_empty_ungroup":     "(leave empty to ungroup)"
+    "leave_empty_ungroup":     "(leave empty to ungroup)",
+    "confirm": {
+      "delete_station_title": "Delete station?",
+      "delete_station_msg":   "\"{name}\" will be removed from your stations list."
+    }
   },
   "workout_editor": {
     "toast": {
@@ -859,7 +906,20 @@
     "duration":                "Duration",
     "feedback_ph":             "Form, intensity, what to push next…",
     "notes":                   "Notes",
-    "template":                "Workout Template"
+    "template":                "Workout Template",
+    "confirm": {
+      "release_coachee_title":     "Release coachee?",
+      "release_coachee_msg":       "Remove {name} from your coaching roster? Their account stays — you'll just no longer be their coach, and any prescriptions or program assignments you've given them will be removed.",
+      "release_confirm":           "Release",
+      "delete_note_title":         "Delete this note?",
+      "delete_workout_note_msg":   "Your workout-level feedback for this session will be removed.",
+      "delete_exercise_note_msg":  "Your note on this exercise will be removed.",
+      "remove_program_title":      "Remove program?",
+      "remove_program_msg":        "Remove {program} from {name}'s assigned programs?",
+      "remove_confirm":            "Remove",
+      "remove_prescription_title": "Remove prescription?",
+      "remove_prescription_msg":   "The member will no longer see this prescription in their diary."
+    }
   },
   "settings_main": {
     "toast": {

--- a/src/routes/Coaching.svelte
+++ b/src/routes/Coaching.svelte
@@ -136,9 +136,9 @@
     if (!memberId || !overview?.user) return;
     const name = memberLabel(overview.user);
     if (!await confirmDialog({
-      title: 'Release coachee?',
-      message: `Remove ${name} from your coaching roster? Their account stays — you'll just no longer be their coach, and any prescriptions or program assignments you've given them will be removed.`,
-      confirmText: 'Release',
+      title: $_('coaching.confirm.release_coachee_title'),
+      message: $_('coaching.confirm.release_coachee_msg', { values: { name } }),
+      confirmText: $_('coaching.confirm.release_confirm'),
       dangerous: true,
     })) return;
     try {
@@ -238,9 +238,9 @@
   async function deleteWorkoutFeedback() {
     if (!workoutDetail) return;
     if (!await confirmDialog({
-      title: 'Delete this note?',
-      message: 'Your workout-level feedback for this session will be removed.',
-      confirmText: 'Delete',
+      title: $_('coaching.confirm.delete_note_title'),
+      message: $_('coaching.confirm.delete_workout_note_msg'),
+      confirmText: $_('common.delete'),
       dangerous: true,
     })) return;
     workoutNote = '';
@@ -268,9 +268,9 @@
   async function deleteExerciseFeedback(idx) {
     if (!workoutDetail || idx == null) return;
     if (!await confirmDialog({
-      title: 'Delete this note?',
-      message: 'Your note on this exercise will be removed.',
-      confirmText: 'Delete',
+      title: $_('coaching.confirm.delete_note_title'),
+      message: $_('coaching.confirm.delete_exercise_note_msg'),
+      confirmText: $_('common.delete'),
       dangerous: true,
     })) return;
     exerciseNotes[idx] = '';
@@ -287,9 +287,9 @@
   async function unassignProgram(programId, programName) {
     if (!memberId) return;
     if (!await confirmDialog({
-      title: 'Remove program?',
-      message: `Remove ${programName} from ${memberLabel(overview?.user)}'s assigned programs?`,
-      confirmText: 'Remove',
+      title: $_('coaching.confirm.remove_program_title'),
+      message: $_('coaching.confirm.remove_program_msg', { values: { program: programName, name: memberLabel(overview?.user) } }),
+      confirmText: $_('coaching.confirm.remove_confirm'),
       dangerous: true,
     })) return;
     try {
@@ -419,7 +419,7 @@
   }
 
   async function deletePrescription(id) {
-    if (!await confirmDialog({ title: 'Remove prescription?', message: 'The member will no longer see this prescription in their diary.', confirmText: 'Remove', dangerous: true })) return;
+    if (!await confirmDialog({ title: $_('coaching.confirm.remove_prescription_title'), message: $_('coaching.confirm.remove_prescription_msg'), confirmText: $_('coaching.confirm.remove_confirm'), dangerous: true })) return;
     try {
       await LtApi.deletePrescription(id);
       prescriptions = prescriptions.filter(p => p.id !== id);

--- a/src/routes/Diary.svelte
+++ b/src/routes/Diary.svelte
@@ -397,9 +397,9 @@
 
   async function deleteReply(fbId) {
     if (!await confirmDialog({
-      title: 'Delete your reply?',
-      message: 'Your reply to this note will be removed.',
-      confirmText: 'Delete',
+      title: $_('diary.confirm.delete_reply_title'),
+      message: $_('diary.confirm.delete_reply_msg'),
+      confirmText: $_('common.delete'),
       dangerous: true,
     })) return;
     replyDrafts[fbId] = '';
@@ -475,7 +475,7 @@
       showError($_('diary_extra.toast.no_exercises')); return;
     }
     if ($todayLog?.exercises?.length > 0) {
-      if (!await confirmDialog({ title: 'Replace workout?', message: 'Loading the suggested workout will overwrite your current workout for today.', confirmText: 'Replace', dangerous: true })) return;
+      if (!await confirmDialog({ title: $_('diary.confirm.replace_workout_title'), message: $_('diary.confirm.replace_suggested_msg'), confirmText: $_('diary.confirm.replace_confirm'), dangerous: true })) return;
     }
     await loadTemplate({
       exercises: exs,
@@ -658,7 +658,7 @@
     const action = e.detail?.value;
     if (action === 'replace') {
       if (($todayLog?.exercises?.length || 0) > 0
-          && !await confirmDialog({ title: 'Replace workout?', message: 'Picking a new template will overwrite your current workout for today.', confirmText: 'Replace', dangerous: true })) return;
+          && !await confirmDialog({ title: $_('diary.confirm.replace_workout_title'), message: $_('diary.confirm.replace_template_msg'), confirmText: $_('diary.confirm.replace_confirm'), dangerous: true })) return;
       openLoadWorkout();
     } else if (action === 'clear') {
       await saveWorkout($currentDate, { ...($todayLog || {}), name: '', template_id: null, program_id: null, exercises: [], notes: '' });
@@ -885,7 +885,7 @@
       showError($_('diary_extra.toast.no_exercises')); return;
     }
     if ($todayLog?.exercises?.length > 0) {
-      if (!await confirmDialog({ title: 'Replace workout?', message: 'Loading the prescribed workout will overwrite your current workout for today.', confirmText: 'Replace', dangerous: true })) return;
+      if (!await confirmDialog({ title: $_('diary.confirm.replace_workout_title'), message: $_('diary.confirm.replace_prescribed_msg'), confirmText: $_('diary.confirm.replace_confirm'), dangerous: true })) return;
     }
     // Reuse the template-load code path via a synthetic template object
     const syntheticProgram = selectedProgram;
@@ -1283,9 +1283,9 @@
     if ($confirmExerciseRemoval) {
       const name = exercises[idx]?.exercise_name || 'this exercise';
       if (!await confirmDialog({
-        title: 'Remove exercise?',
-        message: `${name} will be removed from today's workout.`,
-        confirmText: 'Remove',
+        title: $_('diary.confirm.remove_exercise_title'),
+        message: $_('diary.confirm.remove_exercise_msg', { values: { name } }),
+        confirmText: $_('diary.confirm.remove_confirm'),
         dangerous: true,
       })) return;
     }
@@ -1464,9 +1464,9 @@
         .filter(Boolean);
       const list = names.length ? names.join(', ') : 'All exercises in this superset';
       if (!await confirmDialog({
-        title: 'Remove superset?',
-        message: `${list} will be removed from today's workout.`,
-        confirmText: 'Remove',
+        title: $_('diary.confirm.remove_superset_title'),
+        message: $_('diary.confirm.remove_superset_msg', { values: { list } }),
+        confirmText: $_('diary.confirm.remove_confirm'),
         dangerous: true,
       })) return;
     }

--- a/src/routes/ExerciseDetail.svelte
+++ b/src/routes/ExerciseDetail.svelte
@@ -32,9 +32,9 @@
 
   async function removeExercise() {
     if (!await confirmDialog({
-      title: `Delete "${exercise.name}"?`,
-      message: 'This removes the exercise from your library. Any workouts that logged it keep their history — only the link breaks.',
-      confirmText: 'Delete', dangerous: true,
+      title: $_('exercise_detail.confirm.delete_title', { values: { name: exercise.name } }),
+      message: $_('exercise_detail.confirm.delete_msg'),
+      confirmText: $_('common.delete'), dangerous: true,
     })) return;
     try {
       await LtApi.deleteExercise(exercise.id);

--- a/src/routes/ProgramDetail.svelte
+++ b/src/routes/ProgramDetail.svelte
@@ -126,7 +126,7 @@
 
   async function deleteTemplate(e, id) {
     e.stopPropagation();
-    if (!await confirmDialog({ title: 'Delete workout?', message: 'This removes the workout template from this program.', confirmText: 'Delete', dangerous: true })) return;
+    if (!await confirmDialog({ title: $_('program_detail.confirm.delete_workout_title'), message: $_('program_detail.confirm.delete_workout_msg'), confirmText: $_('common.delete'), dangerous: true })) return;
     try {
       await LtApi.deleteTemplate(id);
       showSuccess($_('program_detail.toast.workout_deleted'));
@@ -135,7 +135,7 @@
   }
 
   async function deleteProgram() {
-    if (!await confirmDialog({ title: 'Delete program?', message: 'Deletes the entire program and all of its workouts. This cannot be undone.', confirmText: 'Delete', dangerous: true })) return;
+    if (!await confirmDialog({ title: $_('program_detail.confirm.delete_program_title'), message: $_('program_detail.confirm.delete_program_msg'), confirmText: $_('common.delete'), dangerous: true })) return;
     try {
       await LtApi.deleteProgram(params.id);
       showSuccess($_('program_detail.toast.program_deleted'));

--- a/src/routes/Radio.svelte
+++ b/src/routes/Radio.svelte
@@ -325,9 +325,9 @@
   // Now-playing: `streamNowPlaying` store is driven globally by player.js.
   async function deleteStation(s) {
     if (!await confirmDialog({
-      title: 'Delete station?',
-      message: `"${s.name}" will be removed from your stations list.`,
-      confirmText: 'Delete',
+      title: $_('radio.confirm.delete_station_title'),
+      message: $_('radio.confirm.delete_station_msg', { values: { name: s.name } }),
+      confirmText: $_('common.delete'),
       dangerous: true,
     })) return;
     $radioStations = ($radioStations || []).filter(x => x.id !== s.id);


### PR DESCRIPTION
Last of the four surfaces. This one was the easiest of the three to write, and that is down to how `confirmDialog` is built: one store, one `Dialog.svelte`, and every screen calling the same function with the same shape. 21 call sites and there was no special case to work around.

46 keys, 21 call sites, 8 files. Nothing user-visible, so no CHANGELOG entry.

Four commits, keys first and then the call sites grouped by area, so every intermediate commit is `i18n:check`-green and stays bisectable if you apply them one at a time.

**Where the value is: reuse.** `common.delete` already held exactly `Delete`, so it now backs the confirm button at ten of the call sites, and `common.cancel` covers the plain `Cancel` ones. That is ten fewer keys for you to read.

**Where I deliberately did not reuse.** `ProgramDetail`'s delete-program dialog and the pre-existing `programs.delete_title` / `delete_message` have identical titles, so collapsing them looks free. Their messages differ by one word: `Deletes the entire program and all of its workouts` versus `Deletes the program and all of`. Reusing would have silently changed one screen's copy, so that dialog got its own keys. Same reasoning for `SettingsWorkoutImport`'s `Skip duplicates`, which is a `cancelText` but not the word `Cancel`, so it is its own key rather than being folded into `common.cancel`.

**One thing worth your opinion, and it is two keys either way.** `Remove` appears as the confirm button on four dialogs across `Coaching` and `Diary`. I gave it per-screen keys rather than adding a `common.remove`, because your dictionary already scopes one of these: `settings_workout.body_stats.remove_title` holds the same word. So per-screen matches what is there, and adding to the shared `common` section felt like a structural choice rather than an extraction. If you would rather centralise it, it collapses to one key.

**Left alone on purpose.** The `ActionSheet` `label:` strings in these same files are the same shape as what I just extracted, and I did not touch them: they collide with existing keys of different casing (a sheet reads `Move up` while `workout_editor.move_up` holds `Move Up`), so extracting them means either changing what users read or minting near-duplicates. That is your call, not a side effect of this PR. `src/stores/confirmDialog.js` is untouched too, so nothing tried to subscribe to `$_` outside a component.

Verified: `npm run i18n:check` red then green on each commit, `npm test` 29/29, `npm run build` clean. Every value compared against the literal it replaced, character for character, including the em dashes, the middle dot, and the escaped-quote convention your `radio.toast.renamed_to` already uses. The interpolation names were checked by hand at every call site that passes `values`, since a mismatch there renders the placeholder raw and `i18n:check` cannot see it.

That check matters more here than in the other two PRs: a broken dialog string does not surface until someone is one click away from deleting a program, and a wrong key would render an empty confirmation box rather than an obvious `some.missing.key`. So every dialog here was opened in a browser against a dev instance, in both the confirm and the cancel path.

Opening all of them turned up something unrelated to the strings, which is in #39 rather than here: the importer's duplicate-dates dialog renders its cancel button outside the card, because `.btn` is `white-space: nowrap` and two long labels cannot shrink in that flex row.
