### PR TITLE
fix(trace): confirm before clearing the chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to LiftTrace are documented here.
 
 ### Fixed
 
+- **Clearing the AI chat now asks for confirmation.** The clear button in the chat header wiped the whole conversation on a single tap: the message list emptied immediately and the server ran an unconditional `DELETE` on the chat history, which the sync tombstone flow does not cover, so an accidental tap had no way back. The button now goes through the same confirmation dialog the app already uses for its other destructive actions; cancelling leaves the conversation untouched on screen and on the server.
+
 - **Statistics summary cards and the plate calculator no longer show their units in capitals.** Both use uppercased labels, which took the unit symbol along with the name: the progress and volume cards read `MAX KG` / `TOTAL KG`, the body-weight card `CURRENT KG`, the cardio card `TOTAL MIN`, and the plate calculator `TARGET WEIGHT (KG)` with `POUNDS (LBS)` / `KILOGRAMS (KG)` in the converter. Unit symbols are case-sensitive: `kg` is kilograms, `min` is minutes, and `KG` and `MIN` are not units at all. The symbols now sit in the same `.unit` span that already keeps the body stats sheet and the rest field correct, so the labels read `MAX kg`, `TOTAL min` and `TARGET WEIGHT (kg)`. Names stay uppercase and no wording changes.
 
 ---

--- a/src/components/ai/Trace.svelte
+++ b/src/components/ai/Trace.svelte
@@ -14,6 +14,7 @@
   import { currentDate, todayLog, activeProgram, saveWorkout } from '../../stores/workout.js';
   import { isPlaying, currentTrack, getAudioForAnalyser } from '../../stores/player.js';
   import { showError } from '../../stores/toast.js';
+  import { confirmDialog } from '../../stores/confirmDialog.js';
   import { parseInput as smartParse, matchExercises, mergeIntoWorkout } from '../../lib/smartLogWorkout.js';
   import SmartLogModal from '../diary/SmartLogModal.svelte';
   import TraceFaceMusic from './TraceFaceMusic.svelte';
@@ -670,6 +671,12 @@ Follow the PLAN line with a SHORT rationale (1-3 sentences) explaining the choic
   }
 
   async function clearHistory() {
+    if (!await confirmDialog({
+      title: $_('trace.clear_confirm_title'),
+      message: $_('trace.clear_confirm_message'),
+      confirmText: $_('trace.clear_confirm_ok'),
+      dangerous: true,
+    })) return;
     messages = [];
     fetch('/api/ai/history', { method: 'DELETE', credentials: 'include' }).catch(() => {});
   }

--- a/src/components/ui/Dialog.svelte
+++ b/src/components/ui/Dialog.svelte
@@ -60,7 +60,7 @@
     background: var(--overlay);
     backdrop-filter: var(--backdrop-blur);
     -webkit-backdrop-filter: var(--backdrop-blur);
-    z-index: 150;
+    z-index: 600; /* above floating overlays that can trigger confirms: Trace panel (450), full player (510) */
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -225,6 +225,9 @@
     "fab_tooltip":        "Tap to chat · hold to voice-log",
     "ask_placeholder":    "Ask me anything…",
     "clear_conversation": "Clear chat",
+    "clear_confirm_title": "Clear this conversation?",
+    "clear_confirm_message": "The messages in this conversation will be deleted. This can't be undone.",
+    "clear_confirm_ok": "Clear",
     "attach_image":       "Attach image"
   },
   "wizard": {


### PR DESCRIPTION
Thanks for the quick turnaround on the last batch — v1.1.2 the same day, and the soft-delete + resurrect you landed for #49 that evening is a really clean way out of that hole.

One more small thing from daily use: the clear button in Trace's header wipes the whole conversation on a single tap. `clearHistory()` (`src/components/ai/Trace.svelte:672`) empties the list immediately and fires `DELETE /api/ai/history`, and since that route hard-deletes (`server/routes/ai.js:45`) rather than writing a `deleted_at` tombstone, an accidental tap on a header icon loses everything with no way back.

This adds the guard the app's other destructive actions already use: `confirmDialog()` with the `dangerous` variant, so it reuses the mount that's already in `App.svelte` and adds no new UI. Cancelling (button, Escape or backdrop) leaves the conversation untouched on screen and on the server; confirming behaves exactly as before.

The three strings are new `trace.*` keys in `en.json`. The copy deliberately says "this conversation" instead of "your whole history": if the history ever splits into separate conversations, the same dialog still reads fine and only the endpoint has to change.

One line lands outside `Trace.svelte`: the dialog backdrop in `Dialog.svelte` moves from `z-index: 150` to `600`. Every existing `confirmDialog()` call fires from page level, so 150 never showed; the chat panel sits at 450, and the dialog opened behind it. 600 puts confirms above the panel and the radio full player (510) while staying below the TimePicker overlay (9999).

One thing I noticed and left alone, since it's a server concern with sync implications: the DELETE itself stays a hard delete outside the tombstone flow, so a cleared history doesn't propagate through sync the way other deletions do. Mentioning it in case it's useful; entirely your call.

Verified on my instance: cancel keeps the conversation (on screen and after a reload), confirm clears it for good. `npm run i18n:check` passes (1299 keys, all references resolve).
