### PR TITLE
feat(trace): render the coach's markdown in the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to LiftTrace are documented here.
 
 ## Unreleased
 
+### Added
+
+- **The coach's replies now render their markdown.** Trace answers with markdown formatting (lists, bold, tables, the occasional code block) and the chat printed all of it raw, asterisks and pipes included. Assistant bubbles now render it through markdown-it with `html: false` (model output cannot inject HTML; the renderer escapes it), `linkify: false`, and `breaks: true` (single newlines stay line breaks, matching how the bubbles wrapped before). User messages stay plain text.
+
 ### Fixed
 
 - **Clearing the AI chat now asks for confirmation.** The clear button in the chat header wiped the whole conversation on a single tap: the message list emptied immediately and the server ran an unconditional `DELETE` on the chat history, which the sync tombstone flow does not cover, so an accidental tap had no way back. The button now goes through the same confirmation dialog the app already uses for its other destructive actions; cancelling leaves the conversation untouched on screen and on the server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lifttrace",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lifttrace",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@aparajita/capacitor-biometric-auth": "^10.0.0",
@@ -30,6 +30,7 @@
         "@zxcvbn-ts/language-common": "^3.0.4",
         "@zxcvbn-ts/language-en": "^3.0.2",
         "hls.js": "^1.6.16",
+        "markdown-it": "^15.0.0",
         "svelte-i18n": "^4.0.1",
         "svelte-spa-router": "^4.0.2"
       },
@@ -3303,6 +3304,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -4009,6 +4026,18 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -5467,6 +5496,25 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/localforage": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
@@ -5533,6 +5581,33 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5542,6 +5617,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/memoizee": {
       "version": "0.4.17",
@@ -5931,6 +6012,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7176,6 +7266,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@zxcvbn-ts/language-common": "^3.0.4",
     "@zxcvbn-ts/language-en": "^3.0.2",
     "hls.js": "^1.6.16",
+    "markdown-it": "^15.0.0",
     "svelte-i18n": "^4.0.1",
     "svelte-spa-router": "^4.0.2"
   },

--- a/src/components/ai/Trace.svelte
+++ b/src/components/ai/Trace.svelte
@@ -686,6 +686,21 @@ Follow the PLAN line with a SHORT rationale (1-3 sentences) explaining the choic
   }
 
   // Render helpers
+  // markdown-it loads lazily (own chunk via dynamic import) the first time
+  // the open panel has an assistant message to show; users who never open
+  // Trace don't pay the bundle cost. Until it resolves, assistant bubbles
+  // fall back to the plain-text branch below, then re-render when `md` lands.
+  // html: false keeps model output from injecting markup through {@html};
+  // breaks: true keeps single newlines as line breaks, like pre-wrap did.
+  let md = null;
+  let mdLoading = null;
+  function loadMd() {
+    if (mdLoading) return;
+    mdLoading = import('markdown-it').then(mod => {
+      md = new mod.default({ html: false, linkify: false, breaks: true });
+    }).catch(() => { mdLoading = null; }); // chunk fetch failed; retry on next trigger
+  }
+  $: if (panelOpen && messages.some(m => m.role === 'assistant' && getText(m.content))) loadMd();
   function getText(content) {
     if (typeof content === 'string') return content;
     return content.filter(p => p.type === 'text').map(p => p.text).join('\n');
@@ -821,7 +836,13 @@ Follow the PLAN line with a SHORT rationale (1-3 sentences) explaining the choic
                   {#each getImages(msg.content) as img}
                     <img class="lb-msg-img" src={img.dataUrl} alt="attachment" />
                   {/each}
-                  {#if getText(msg.content)}{getText(msg.content)}{/if}
+                  {#if getText(msg.content)}
+                    {#if msg.role === 'assistant' && md}
+                      <div class="lb-md">{@html md.render(getText(msg.content))}</div>
+                    {:else}
+                      {getText(msg.content)}
+                    {/if}
+                  {/if}
                 </div>
                 {#if plan}
                   <button class="lb-plan-apply" on:click={() => useGeneratedPlan(plan)}>
@@ -1176,6 +1197,36 @@ Follow the PLAN line with a SHORT rationale (1-3 sentences) explaining the choic
   .lb-time {
     font-size: 10px; color: var(--text-3);
     padding: 0 4px;
+  }
+  /* Markdown body in assistant bubbles. The HTML comes from {@html}, so the
+     selectors need :global(); white-space resets the bubble's pre-wrap because
+     the rendered HTML carries its own block structure. */
+  .lb-md { white-space: normal; }
+  .lb-md :global(p),
+  .lb-md :global(ul), .lb-md :global(ol),
+  .lb-md :global(pre), .lb-md :global(blockquote),
+  .lb-md :global(table) { margin: 0 0 8px; }
+  .lb-md :global(:last-child) { margin-bottom: 0; }
+  .lb-md :global(ul), .lb-md :global(ol) { padding-left: 20px; }
+  .lb-md :global(h1), .lb-md :global(h2), .lb-md :global(h3),
+  .lb-md :global(h4) { font-size: 14px; margin: 10px 0 6px; }
+  .lb-md :global(code) {
+    font-size: 12.5px; background: var(--surface-3);
+    padding: 1px 5px; border-radius: 6px;
+  }
+  .lb-md :global(pre) {
+    background: var(--surface-3); padding: 8px 10px;
+    border-radius: 10px; overflow-x: auto;
+  }
+  .lb-md :global(pre code) { background: none; padding: 0; }
+  .lb-md :global(a) { color: var(--accent); }
+  .lb-md :global(blockquote) {
+    border-left: 3px solid var(--border);
+    padding-left: 10px; color: var(--text-2);
+  }
+  .lb-md :global(table) { border-collapse: collapse; }
+  .lb-md :global(th), .lb-md :global(td) {
+    border: 1px solid var(--border); padding: 4px 8px; text-align: left;
   }
 
   /* "Use This Workout", appears under any assistant reply whose text


### PR DESCRIPTION
Follow-up to #51, with your go-ahead on the dependency.

Assistant bubbles now render through markdown-it; user messages stay plain text nodes. The config is `{ html: false, linkify: false, breaks: true }`:

- `html: false` is the line that matters: model output cannot inject markup through `{@html}`, the renderer escapes it, and `javascript:` link destinations come out as plain text.
- `linkify: false`: no surprise autolinking of bare domains.
- `breaks: true`: single newlines stay line breaks, matching how the bubbles wrapped under `white-space: pre-wrap` before.

Both points from your comment are in:

- The renderer is code-split behind `import('markdown-it')`. It loads the first time the open panel has an assistant message to show; the trigger checks `panelOpen` because the history fetch runs on mount, so watching messages alone would have loaded the chunk for anyone with history even with the panel closed. While the chunk resolves the bubble shows the same plain text it showed before, then re-renders in place.
- `_extractPlan(msg.content)` keeps reading the raw message content, not the rendered HTML, so the "Use This Workout" detection is untouched. Checked again after the change.

The markdown body sits in its own `.lb-md` wrapper that resets the bubble's `pre-wrap` (the rendered HTML brings its own block structure), with minimal element styles built on the existing theme tokens so light and dark both work.

Cost, measured on this branch against current dev: 7 packages in the lockfile, a 48.1 KB gzip lazy chunk, and +0.2 KB gzip on the main bundle (360.96 to 361.17). The comparison against micromark and marked/snarkdown is in #51.

Verified on my instance: bulleted lists, bold and tables render properly, single line breaks are kept, user messages stay plain text, and the "Use This Workout" button still shows up on plan replies. The lazy chunk stays unrequested until the open panel has an assistant message, then loads and renders in place. `npm run i18n:check` passes; no new strings, the rendered content is model output.
