### PR TITLE
fix(settings): restore the em-dash mangled to "â€”" in the diagnostics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Italian translation.** Adds a complete `it` locale and exposes it as `Italiano` in the Settings → Units language picker.
 
+### Fixed
+
+- **Settings → Help & Improve showed `â€”` where a dash belonged.** Two visible strings in the diagnostics panel carried a mojibake em-dash from a round-trip through CP1252.
+
 ---
 
 ## [1.1.3-dev01] - 2026-08-16 (pre-release)

--- a/src/components/settings/SettingsDiagnostics.svelte
+++ b/src/components/settings/SettingsDiagnostics.svelte
@@ -1,6 +1,6 @@
 <script>
   /**
-   * Diagnostics â€” in-app log capture + share.
+   * Diagnostics — in-app log capture + share.
    *
    * Lets users grab the in-memory log buffer (~500 lines), turn on verbose
    * mode while reproducing a bug, and copy/share the result without needing
@@ -61,7 +61,7 @@
         await copyLogs();
       }
     } catch (e) {
-      // User cancelled â€” silent.
+      // User cancelled — silent.
     }
   }
 
@@ -92,7 +92,7 @@
             <span class="setting-label">{$_('settings_diagnostics.verbose_logging')}</span>
             <span class="setting-hint">
               Enables detailed app-internal logs (sync, settings, notifications, SQLite). Off by
-              default â€” turn on while reproducing a bug, then export below.
+              default — turn on while reproducing a bug, then export below.
             </span>
           </div>
           <Toggle checked={verboseOn} on:change={e => toggleVerbose(e.detail)} />
@@ -103,7 +103,7 @@
         <div class="setting-row" style="flex-direction:column;align-items:flex-start;gap:8px">
           <span class="setting-label">{$_('settings_diagnostics.view_logs')}</span>
           <p class="setting-hint" style="line-height:1.5;margin:0">
-            Last 500 lines from the app's console. Useful for bug reports â€” copy or share to a
+            Last 500 lines from the app's console. Useful for bug reports — copy or share to a
             <a href="https://github.com/TraceApps/lifttrace/issues" target="_blank" rel="noopener" style="color:var(--accent)">GitHub issue</a>.
             The buffer holds in-memory only; nothing is sent anywhere automatically.
           </p>


### PR DESCRIPTION
Spotted while going through the Spanish locale on a dev build: Settings → Help & Improve shows `â€”` where a dash should be, in two places the user actually reads. The verbose-logging description ("Off by default â€” turn on while reproducing a bug") and the note under the log viewer ("Useful for bug reports â€— copy or share to a GitHub issue").

The bytes in the file are `C3 A2 / E2 82 AC / E2 80 9D`, which is a UTF-8 em-dash (`E2 80 94`) decoded as CP1252 and written back out, so the file passed through something that guessed the wrong incoming charset. Restored to U+2014. Two comments in the same file had picked it up too, so they go with it.

I grepped the rest of the repo for that pattern and for the other usual mojibake shapes: no other hits, it is just this one file.

Nothing else touched, and the strings themselves are unchanged apart from the one character.
