### PR TITLE
fix(ui): version renders as "vv1.1.3-dev01" in About and the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Italian translation.** Adds a complete `it` locale and exposes it as `Italiano` in the Settings → Units language picker.
 
+### Fixed
+
+- **The version no longer reads `vv1.1.3-dev01`.** Settings → About and the desktop sidebar both prefixed a literal `v` onto `APP_VERSION`, which already carries one.
+
 ---
 
 ## [1.1.3-dev01] - 2026-08-16 (pre-release)

--- a/src/components/layout/Sidebar.svelte
+++ b/src/components/layout/Sidebar.svelte
@@ -117,7 +117,7 @@
           </button>
         </div>
       {:else}
-        <span class="sidebar-version">LiftTrace v{APP_VERSION}</span>
+        <span class="sidebar-version">LiftTrace {APP_VERSION}</span>
       {/if}
     </div>
   </aside>

--- a/src/components/settings/SettingsAbout.svelte
+++ b/src/components/settings/SettingsAbout.svelte
@@ -28,7 +28,7 @@
           <div>
             <div class="about-name">{$_('settings_about.app_name')}</div>
             <div class="about-version">
-              v{APP_VERSION}
+              {APP_VERSION}
               <span class="platform-tag">{isNative ? 'Android' : 'PWA'}</span>
             </div>
           </div>


### PR DESCRIPTION
Small display bug: Settings → About reads `vv1.1.3-dev01`, and on desktop the sidebar reads `LiftTrace vv1.1.3-dev01`.

`APP_VERSION` in `src/lib/version.js` already carries the leading `v`, and two of its three call sites add a second one: `SettingsAbout.svelte:31` renders `v{APP_VERSION}`, `Sidebar.svelte:120` renders `LiftTrace v{APP_VERSION}`. The third, `SettingsUpdates.svelte:230`, interpolates it bare and reads correctly, so I matched that one rather than touching the constant. That way nothing else that reads `APP_VERSION` needs a second look.

Noticed it on a `:dev` build while checking something else, so the version string in the screenshots is `1.1.3-dev01`, but it applies to any version.
