### PR TITLE
fix(settings): the Units section holds mostly regional settings, not units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Italian translation.** Adds a complete `it` locale and exposes it as `Italiano` in the Settings → Units language picker.
 
+### Changed
+
+- **Settings → Units is now Settings → Language & Region**, with a globe icon instead of the ruler. The section holds the language picker, date format and time format alongside the weight unit, so three of its four rows were regional settings rather than units.
+
 ---
 
 ## [1.1.3-dev01] - 2026-08-16 (pre-release)

--- a/src/components/settings/SettingsUnits.svelte
+++ b/src/components/settings/SettingsUnits.svelte
@@ -11,7 +11,7 @@
 
 {#if visible}
   <button class="section-toggle" on:click={onToggle}>
-    <span class="si"><span class="material-symbols-rounded">straighten</span></span>
+    <span class="si"><span class="material-symbols-rounded">language</span></span>
     <span class="section-name">{$_('settings.units.section')}</span>
     <span class="material-symbols-rounded chevron" class:rotated={expanded}>expand_more</span>
   </button>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -361,7 +361,7 @@
   },
   "settings": {
     "units": {
-      "section":  "Units",
+      "section":  "Language & Region",
       "language": "Language"
     },
     "appearance":      {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -383,7 +383,7 @@
   },
   "settings": {
     "units": {
-      "section": "Unidades",
+      "section": "Idioma y región",
       "language": "Idioma"
     },
     "appearance": {

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -402,7 +402,7 @@
   const SECTION_META = {
     profile:          { titleKey: 'profile.title',                      icon: 'person' },
     appearance:       { titleKey: 'settings.appearance.section',        icon: 'contrast' },
-    units:            { titleKey: 'settings.units.section',             icon: 'straighten' },
+    units:            { titleKey: 'settings.units.section',             icon: 'language' },
     workout:          { titleKey: 'settings.workout.section',           icon: 'fitness_center' },
     statistics:       { titleKey: 'settings.statistics.section',        icon: 'bar_chart' },
     catalog:          { titleKey: 'settings.catalog.section',           icon: 'library_books' },
@@ -654,7 +654,7 @@
     <span class="material-symbols-rounded chevron">chevron_right</span>
   </button>
   <button class="section-toggle rail-btn" class:hidden={!sectionVisible(settingsQuery, 'units')} class:active={currentSection === 'units'} aria-current={currentSection === 'units' ? 'page' : undefined} on:click={() => toggleSection('units')}>
-    <span class="material-symbols-rounded si">straighten</span>
+    <span class="material-symbols-rounded si">language</span>
     <span>{$_('settings.units.section')}</span>
     <span class="material-symbols-rounded chevron">chevron_right</span>
   </button>


### PR DESCRIPTION
Working through the Spanish locale, I kept losing the language picker. It lives in Settings → Units, behind a ruler icon, which is not where anyone looks for it.

Then I opened the section and it turns out the naming is the odd part, not the placement. `SettingsUnits.svelte` holds four rows: language, weight unit, date format, time format. Three of those four are regional conventions rather than units of measurement, so "Units" plus a ruler describes one row out of four.

So rather than move the language row out (which would separate it from date and time format, where it belongs), this just renames the section to **Language & Region** and swaps the icon to `language`. Three render sites: the collapsible header in `SettingsUnits.svelte`, and `SECTION_META` plus the sub-page header in `Settings.svelte`. No rows move, and the key stays `settings.units.section` so nothing downstream shifts.

If you would rather call it something else, it is one value in `en.json` and I am happy either way. "Regional & Units" also works if you want the units part to stay visible in the name.

Two notes:

- Spanish is updated in the same pass. Italian still reads "Unita" and needs one word, but it is not my locale so I left it; Weblate should flag it on the next sync.
- `npm run i18n:check` stays green. The 9 missing keys it reports for es and it are the new `updates.*` block from yesterday, unrelated to this.
