### PR TITLE
ci: add manual GHCR tag-prune workflow

### DIFF
--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -1,0 +1,66 @@
+name: Prune stale GHCR tags
+
+# Only :latest and :dev are supposed to exist on ghcr.io per
+# .github/workflows/docker.yml + feedback_traceapps_docker_tags. Anything
+# else accumulates from historical CI (per-commit SHA tags, semver tags
+# from before the two-tag policy) and leaves users with pinnable-but-
+# stale references. This job enforces the policy.
+#
+# Starts as workflow_dispatch only so the first few runs are manual +
+# reviewable. After it's proven safe, a weekly `schedule:` block can be
+# added (Sundays 03:00 UTC is fine — off-peak, low churn day).
+#
+# Preserves:
+#   - any version tagged :latest or :dev
+#   - untagged versions (multi-arch manifests reference these by digest)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune GHCR tags other than :latest and :dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: traceapps
+          PACKAGE: lifttrace
+        run: |
+          set -euo pipefail
+
+          # Every tagged version whose tag set contains NO entry in the
+          # allowlist. Tab-separated: <id>\t<comma-joined tags>.
+          mapfile -t VICTIMS < <(
+            gh api "orgs/$OWNER/packages/container/$PACKAGE/versions" \
+              --paginate \
+              --jq '.[]
+                | select(.metadata.container.tags | length > 0)
+                | select([.metadata.container.tags[]
+                    | select(. == "latest" or . == "dev")] | length == 0)
+                | "\(.id)\t\(.metadata.container.tags | join(","))"'
+          )
+
+          if [ ${#VICTIMS[@]} -eq 0 ]; then
+            echo "Nothing to prune — every tagged version carries :latest or :dev."
+            exit 0
+          fi
+
+          echo "Found ${#VICTIMS[@]} stale version(s):"
+          for row in "${VICTIMS[@]}"; do
+            id=$(echo "$row" | cut -f1)
+            tags=$(echo "$row" | cut -f2)
+            echo "  - version $id  tags: $tags"
+          done
+
+          for row in "${VICTIMS[@]}"; do
+            id=$(echo "$row" | cut -f1)
+            tags=$(echo "$row" | cut -f2)
+            echo "Deleting version $id (tags: $tags)"
+            gh api -X DELETE "orgs/$OWNER/packages/container/$PACKAGE/versions/$id"
+          done
+
+          echo "Pruned ${#VICTIMS[@]} stale version(s)."


### PR DESCRIPTION
Cherry-picks the ghcr-prune workflow (added on dev in f9d3c56) to main so it becomes triggerable via the Actions UI. Adds no runtime code, only `.github/workflows/ghcr-prune.yml`.

Motivated by #59 — need to clean up stale `:1.1` and `:1` tags on ghcr.io that survived from before the two-tag policy went in, and want a repeatable way to prune future stragglers.