### PR TITLE
i18n(settings): route strings through $_() in six section components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ First dev pre-release of the 1.2.0 minor. Bumped from the 1.1.3 patch line becau
 
 - **Settings → Units is now Settings → Language & Region** ([#62](https://github.com/TraceApps/lifttrace/pull/62), thanks @backmind). The section holds the language picker, date format, and time format alongside the weight unit, so three of its four rows were regional settings rather than units. Section header + icon (globe instead of ruler) updated across the collapsible view, the desktop rail, and the sub-page header. English, Spanish, and Italian labels updated in the same commit; settings search picks up `language` as a keyword so the section still comes up under its old name too.
 
+- **The Radio, NutriTrace, Diagnostics, About, Workout, and Users sections of Settings no longer hard-code English copy.** 38 strings that lived as literals in those six components (section hints, the About description and disclaimer, the rest-timer tone names, and a few labels built in JavaScript) now resolve through the i18n layer, so translations can pick them up. English output is unchanged.
+
 ---
 
 ## [1.1.3-dev01] - 2026-08-16 (pre-release)

--- a/src/components/settings/SettingsAbout.svelte
+++ b/src/components/settings/SettingsAbout.svelte
@@ -35,25 +35,22 @@
         </div>
         <div class="setting-divider"></div>
         <div class="about-desc">
-          Track Every Rep — Personal Weightlifting Tracker. LiftTrace is a self-hosted
-          workout tracker built for privacy. Your data lives on your server, not in the cloud.
-          Features workout diary, program builder, multi-source exercise library, AI coaching,
-          statistics, and more.
+          {$_('settings_about.description')}
         </div>
         <div class="setting-divider"></div>
         <div class="about-row">
           <span class="material-symbols-rounded about-feat-icon">database</span>
-          <span>Self-hosted — your data, your server</span>
+          <span>{$_('settings_about.feature_self_hosted')}</span>
         </div>
         <div class="setting-divider"></div>
         <div class="about-row">
           <span class="material-symbols-rounded about-feat-icon">install_mobile</span>
-          <span>PWA — installable on any device</span>
+          <span>{$_('settings_about.feature_pwa')}</span>
         </div>
         <div class="setting-divider"></div>
         <div class="about-row">
           <span class="material-symbols-rounded about-feat-icon">lock</span>
-          <span>No tracking, no ads, no third-party analytics</span>
+          <span>{$_('settings_about.feature_privacy')}</span>
         </div>
         <div class="setting-divider"></div>
         <div class="about-row">
@@ -79,31 +76,18 @@
             </a>
             -->
             <a href="https://ko-fi.com/traceapps" target="_blank" rel="noopener" class="btn btn-secondary" style="height:30px;font-size:12px;padding:0 12px">
-              <span class="material-symbols-rounded" style="font-size:14px">coffee</span> Ko-fi
+              <span class="material-symbols-rounded" style="font-size:14px">coffee</span> {$_('settings_about.kofi')}
             </a>
           </div>
-          <div class="setting-desc" style="padding-left:30px;font-size:11px">LiftTrace is free to self-host. Donations are appreciated but never required.</div>
+          <div class="setting-desc" style="padding-left:30px;font-size:11px">{$_('settings_about.donations_note')}</div>
         </div>
         <div class="setting-divider"></div>
         <div class="about-desc" style="font-size:11px;color:var(--text-3);line-height:1.5">
-          <strong>Disclaimer.</strong> LiftTrace is not medical, health, or fitness-professional
-          software. It does not provide medical advice, diagnosis, treatment, or personalized
-          training prescriptions. Exercise library content, Trace AI coaching, program templates,
-          rest-timer guidance, and any analytical output (volume, PRs, frequency, body-weight
-          trends) are for informational and self-tracking purposes only.
+          <strong>{$_('settings_about.disclaimer_heading')}</strong> {$_('settings_about.disclaimer_medical')}
           <br /><br />
-          Resistance training carries inherent risk of injury. Exercise selection, load, technique,
-          and progression can interact with medical conditions (heart and cardiovascular conditions,
-          high blood pressure, prior surgery, hernias, joint or spinal issues, osteoporosis,
-          pregnancy, connective-tissue disorders, recent injury or rehabilitation status) in ways
-          this app cannot assess. Consult a qualified healthcare professional, certified strength
-          coach, or licensed physical therapist before starting a new training program, returning
-          from injury, or making significant changes to your routine.
+          {$_('settings_about.disclaimer_risk')}
           <br /><br />
-          Trace AI answers can be incorrect or incomplete; treat them as a starting point, not a
-          substitute for human judgment or professional advice. Exercise library data is sourced
-          from public databases (wger, Free Exercise DB, optionally ExerciseDB via RapidAPI) and
-          may contain inaccuracies. Use at your own risk.
+          {$_('settings_about.disclaimer_ai')}
         </div>
       </div>
     </div>

--- a/src/components/settings/SettingsDiagnostics.svelte
+++ b/src/components/settings/SettingsDiagnostics.svelte
@@ -91,8 +91,7 @@
           <div class="setting-label-group">
             <span class="setting-label">{$_('settings_diagnostics.verbose_logging')}</span>
             <span class="setting-hint">
-              Enables detailed app-internal logs (sync, settings, notifications, SQLite). Off by
-              default — turn on while reproducing a bug, then export below.
+              {$_('settings_diagnostics.verbose_logging_hint')}
             </span>
           </div>
           <Toggle checked={verboseOn} on:change={e => toggleVerbose(e.detail)} />
@@ -103,13 +102,12 @@
         <div class="setting-row" style="flex-direction:column;align-items:flex-start;gap:8px">
           <span class="setting-label">{$_('settings_diagnostics.view_logs')}</span>
           <p class="setting-hint" style="line-height:1.5;margin:0">
-            Last 500 lines from the app's console. Useful for bug reports — copy or share to a
-            <a href="https://github.com/TraceApps/lifttrace/issues" target="_blank" rel="noopener" style="color:var(--accent)">GitHub issue</a>.
-            The buffer holds in-memory only; nothing is sent anywhere automatically.
+            {$_('settings_diagnostics.view_logs_hint_prefix')}
+            <a href="https://github.com/TraceApps/lifttrace/issues" target="_blank" rel="noopener" style="color:var(--accent)">{$_('settings_diagnostics.github_issue')}</a>{$_('settings_diagnostics.view_logs_hint_suffix')}
           </p>
           <button class="btn btn-secondary" style="height:40px;font-size:13px" on:click={openLogsSheet}>
             <span class="material-symbols-rounded" style="font-size:16px;vertical-align:-3px">terminal</span>
-            View logs
+            {$_('settings_diagnostics.view_logs_button')}
           </button>
         </div>
       </div>

--- a/src/components/settings/SettingsFederation.svelte
+++ b/src/components/settings/SettingsFederation.svelte
@@ -125,7 +125,7 @@
           <div class="setting-label-group">
             <span class="setting-label">{$_('settings_federation.enable_federation')}</span>
             <span class="setting-hint">
-              Auto-log each completed workout's estimated calories burned to your NutriTrace diary. Workouts appear in NutriTrace under Settings → Wellness → Workout History.
+              {$_('settings_federation.enable_federation_hint')}
             </span>
           </div>
           <Toggle bind:checked={$ntFederationEnabled} />
@@ -144,7 +144,7 @@
         <div class="setting-row" style="flex-wrap:wrap;gap:8px">
           <div class="setting-label-group" style="width:100%">
             <span class="setting-label">{$_('settings_federation.instance_url')}</span>
-            <span class="setting-hint">Your NutriTrace server, e.g. <code>https://nutritrace.example.com</code></span>
+            <span class="setting-hint">{$_('settings_federation.instance_url_hint')} <code>https://nutritrace.example.com</code></span>
           </div>
           <input class="form-input-sm" style="flex:1;min-width:0;width:100%" type="url"
             bind:value={urlDraft} placeholder="https://nutritrace.example.com"
@@ -155,7 +155,7 @@
           <div class="setting-label-group" style="width:100%">
             <span class="setting-label">{$_('settings_federation.access_token')}</span>
             <span class="setting-hint">
-              Generate in NutriTrace under Settings → User Management → API Tokens with the <code>write:workouts</code> scope.
+              {$_('settings_federation.access_token_hint_prefix')} <code>write:workouts</code> {$_('settings_federation.access_token_hint_suffix')}
             </span>
           </div>
           <div class="key-row">
@@ -180,7 +180,7 @@
           <div class="setting-label-group">
             <span class="setting-label">{$_('settings_federation.wearable_priority')}</span>
             <span class="setting-hint">
-              If you wear a Fitbit / Garmin / Health Connect during your lift, NutriTrace prefers the wearable's calories-burned total to avoid double-counting. Workouts still show in NutriTrace's Workout History either way. Toggle in NutriTrace → Settings → Wellness → "Prefer Wearable Data Over LiftTrace".
+              {$_('settings_federation.wearable_priority_hint')}
             </span>
           </div>
         </div>

--- a/src/components/settings/SettingsRadio.svelte
+++ b/src/components/settings/SettingsRadio.svelte
@@ -79,8 +79,8 @@
         {/if}
         <div class="setting-row">
           <div class="setting-label-group">
-            <span class="setting-label">Self-Hosted Music</span>
-            <span class="setting-hint">Stream from a Subsonic-compatible server (Navidrome, Jellyfin, Airsonic, etc.)</span>
+            <span class="setting-label">{$_('settings_radio.self_hosted')}</span>
+            <span class="setting-hint">{$_('settings_radio.self_hosted_hint')}</span>
           </div>
           <Toggle bind:checked={$radioEnabled} />
         </div>
@@ -90,7 +90,7 @@
         <div class="setting-row">
           <div class="setting-label-group">
             <span class="setting-label">{$_('settings_radio.streaming_stations')}</span>
-            <span class="setting-hint">Listen to internet radio. Add stations from the directory or paste a stream URL.</span>
+            <span class="setting-hint">{$_('settings_radio.streaming_stations_hint')}</span>
           </div>
           <Toggle bind:checked={$radioStationsEnabled} />
         </div>

--- a/src/components/settings/SettingsUserManagement.svelte
+++ b/src/components/settings/SettingsUserManagement.svelte
@@ -366,7 +366,7 @@
                   <span class="user-row-meta">@{u.username}</span>
                   <div class="user-row-selects">
                     {#if u.id === $currentUser.id}
-                      <span class="user-role-badge">{u.role} (you)</span>
+                      <span class="user-role-badge">{u.role} {$_('settings.users.role_self_suffix')}</span>
                     {:else}
                       <select class="form-select-xs" value={u.role} on:change={e => changeUserRole(u, e.target.value)} title="Role">
                         <option value="member">{$_('settings.users.role_member_opt')}</option>
@@ -378,7 +378,7 @@
                       <select class="form-select-xs" value={u.trainer_id || ''} on:change={e => changeUserTrainer(u, e.target.value)} title="Assigned trainer">
                         <option value="">{$_('settings.users.no_trainer')}</option>
                         {#each trainers as t (t.id)}
-                          <option value={t.id}>Coach {t.full_name || t.username}</option>
+                          <option value={t.id}>{$_('settings.users.coach_option', { values: { name: t.full_name || t.username } })}</option>
                         {/each}
                       </select>
                     {/if}
@@ -388,7 +388,7 @@
                   <button class="btn-icon-danger" on:click={() => resetUserPassword(u)} title="Reset Password" style="color:var(--text-3)">
                     <span class="material-symbols-rounded" style="font-size:20px">lock_reset</span>
                   </button>
-                  <button class="btn-icon-danger" on:click={() => deleteUser(u.id)} title="Delete User">
+                  <button class="btn-icon-danger" on:click={() => deleteUser(u.id)} title={$_('settings.users.delete_user')}>
                     <span class="material-symbols-rounded" style="font-size:20px">delete</span>
                   </button>
                 {/if}
@@ -420,7 +420,7 @@
               </div>
             </div>
             <button class="btn btn-primary" style="height:36px;font-size:13px" on:click={inviteUser} disabled={!_inviteCanSubmit}>
-              {inviting ? $_('settings.users.sending') : (_inviteEmailTrimmed ? $_('settings.users.send_invite') : 'Generate Invite Link')}
+              {inviting ? $_('settings.users.sending') : (_inviteEmailTrimmed ? $_('settings.users.send_invite') : $_('settings.users.generate_invite_link'))}
             </button>
             {#if pendingInvites.length > 0}
               <div class="pending-invites" transition:slide={{ duration: 160 }}>
@@ -500,7 +500,7 @@
           <div class="setting-row">
             <div>
               <span class="setting-label">{$_('settings.users.strong_passwords')}</span>
-              <div class="setting-desc">Reject weak passwords (zxcvbn score below 3) on top of the standard 8-char + mixed-case + number + symbol rules. Affects new sign-ups, invites, and password changes. Existing passwords aren't re-checked.</div>
+              <div class="setting-desc">{$_('settings.users.strong_passwords_desc')}</div>
             </div>
             <Toggle checked={passwordPolicy === 'strong'} on:change={e => savePasswordPolicy(e.detail ? 'strong' : 'standard')} />
           </div>

--- a/src/components/settings/SettingsWorkout.svelte
+++ b/src/components/settings/SettingsWorkout.svelte
@@ -17,6 +17,17 @@
   export let visible = true;
   export let onToggle = () => {};
 
+  // Preset names + descriptions live as data in restTones.js; translate at
+  // the render site, keyed by tone id, falling back to the raw strings for
+  // any preset without a key. Mirrors the BODY_STATS pattern below.
+  $: TONE_LABELS = {
+    classic: { name: $_('settings_workout.rest.tones.classic'), desc: $_('settings_workout.rest.tones.classic_desc') },
+    bells:   { name: $_('settings_workout.rest.tones.bells'),   desc: $_('settings_workout.rest.tones.bells_desc') },
+    beeper:  { name: $_('settings_workout.rest.tones.beeper'),  desc: $_('settings_workout.rest.tones.beeper_desc') },
+    gym:     { name: $_('settings_workout.rest.tones.gym'),     desc: $_('settings_workout.rest.tones.gym_desc') },
+    minimal: { name: $_('settings_workout.rest.tones.minimal'), desc: $_('settings_workout.rest.tones.minimal_desc') },
+  };
+
   $: BODY_STATS = [
     { id: 'weight',  label: $_('settings_workout.body_stats.weight') },
     { id: 'bodyFat', label: $_('settings_workout.body_stats.body_fat') },
@@ -53,8 +64,8 @@
         </div>
         <div class="setting-row">
           <div class="setting-label-group">
-            <span class="setting-label">Track Cardio</span>
-            <span class="setting-hint">Log cardio sessions (bike, run, row, etc.) from the Diary and see weekly minutes on Statistics. Off by default so pure lifters aren't cluttered. Manual entry only; device sync stays in NutriTrace.</span>
+            <span class="setting-label">{$_('settings_workout.goals.track_cardio')}</span>
+            <span class="setting-hint">{$_('settings_workout.goals.track_cardio_desc')}</span>
           </div>
           <Toggle bind:checked={$cardioEnabled} />
         </div>
@@ -209,8 +220,8 @@
                     <div class="tone-row" class:active={$restAlertToneId === tone.id}>
                       <button class="tone-main" on:click={() => $restAlertToneId = tone.id}>
                         <div class="tone-info">
-                          <span class="tone-name">{tone.name}</span>
-                          <span class="tone-desc">{tone.desc}</span>
+                          <span class="tone-name">{(TONE_LABELS[tone.id] || tone).name}</span>
+                          <span class="tone-desc">{(TONE_LABELS[tone.id] || tone).desc}</span>
                         </div>
                         {#if $restAlertToneId === tone.id}
                           <span class="material-symbols-rounded tone-selected">check_circle</span>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -474,7 +474,11 @@
       "cancel":                "Cancel",
       "hide":                  "Hide",
       "show":                  "Show",
-      "disable_um_hint":       "Deletes all accounts, app becomes open access"
+      "disable_um_hint":       "Deletes all accounts, app becomes open access",
+      "generate_invite_link":  "Generate Invite Link",
+      "coach_option":          "Coach {name}",
+      "delete_user":           "Delete User",
+      "strong_passwords_desc": "Reject weak passwords (zxcvbn score below 3) on top of the standard 8-char + mixed-case + number + symbol rules. Affects new sign-ups, invites, and password changes. Existing passwords aren't re-checked."
     },
     "server":          { "section": "Server Connection" },
     "workout_import":  { "section": "Import Workouts" },
@@ -502,7 +506,17 @@
     "open_source":           "Open source",
     "sister_app_prefix":     "Sister app: ",
     "sister_app_suffix":     ", nutrition tracker",
-    "support_development":   "Support Development"
+    "support_development":   "Support Development",
+    "description":           "Track Every Rep — Personal Weightlifting Tracker. LiftTrace is a self-hosted workout tracker built for privacy. Your data lives on your server, not in the cloud. Features workout diary, program builder, multi-source exercise library, AI coaching, statistics, and more.",
+    "feature_self_hosted":   "Self-hosted — your data, your server",
+    "feature_pwa":           "PWA — installable on any device",
+    "feature_privacy":       "No tracking, no ads, no third-party analytics",
+    "kofi":                  "Ko-fi",
+    "donations_note":        "LiftTrace is free to self-host. Donations are appreciated but never required.",
+    "disclaimer_heading":    "Disclaimer.",
+    "disclaimer_medical":    "LiftTrace is not medical, health, or fitness-professional software. It does not provide medical advice, diagnosis, treatment, or personalized training prescriptions. Exercise library content, Trace AI coaching, program templates, rest-timer guidance, and any analytical output (volume, PRs, frequency, body-weight trends) are for informational and self-tracking purposes only.",
+    "disclaimer_risk":       "Resistance training carries inherent risk of injury. Exercise selection, load, technique, and progression can interact with medical conditions (heart and cardiovascular conditions, high blood pressure, prior surgery, hernias, joint or spinal issues, osteoporosis, pregnancy, connective-tissue disorders, recent injury or rehabilitation status) in ways this app cannot assess. Consult a qualified healthcare professional, certified strength coach, or licensed physical therapist before starting a new training program, returning from injury, or making significant changes to your routine.",
+    "disclaimer_ai":         "Trace AI answers can be incorrect or incomplete; treat them as a starting point, not a substitute for human judgment or professional advice. Exercise library data is sourced from public databases (wger, Free Exercise DB, optionally ExerciseDB via RapidAPI) and may contain inaccuracies. Use at your own risk."
   },
   "template_spec": {
     "auto":                  "Auto",
@@ -588,15 +602,24 @@
   "settings_federation": {
     "url_token_required":    "Enter a URL and access token first",
     "enable_federation":     "Enable Federation",
+    "enable_federation_hint": "Auto-log each completed workout's estimated calories burned to your NutriTrace diary. Workouts appear in NutriTrace under Settings → Wellness → Workout History.",
     "instance_url":          "Instance URL",
+    "instance_url_hint":     "Your NutriTrace server, e.g.",
     "access_token":          "Access Token",
-    "wearable_priority":     "Wearable Priority"
+    "access_token_hint_prefix": "Generate in NutriTrace under Settings → User Management → API Tokens with the",
+    "access_token_hint_suffix": "scope.",
+    "wearable_priority":     "Wearable Priority",
+    "wearable_priority_hint": "If you wear a Fitbit / Garmin / Health Connect during your lift, NutriTrace prefers the wearable's calories-burned total to avoid double-counting. Workouts still show in NutriTrace's Workout History either way. Toggle in NutriTrace → Settings → Wellness → \"Prefer Wearable Data Over LiftTrace\"."
   },
   "settings_diagnostics": {
     "copy_failed":           "Copy failed, select the text manually",
     "logs_cleared":          "Logs cleared",
     "verbose_logging":       "Verbose Diagnostic Logging",
+    "verbose_logging_hint":  "Enables detailed app-internal logs (sync, settings, notifications, SQLite). Off by default — turn on while reproducing a bug, then export below.",
     "view_logs":             "View Diagnostic Logs",
+    "view_logs_hint_prefix": "Last 500 lines from the app's console. Useful for bug reports — copy or share to a",
+    "view_logs_hint_suffix": ". The buffer holds in-memory only; nothing is sent anywhere automatically.",
+    "view_logs_button":      "View logs",
     "github_issue":          "GitHub issue"
   },
   "smart_log": {
@@ -667,7 +690,10 @@
     }
   },
   "settings_radio": {
+    "self_hosted":           "Self-Hosted Music",
+    "self_hosted_hint":      "Stream from a Subsonic-compatible server (Navidrome, Jellyfin, Airsonic, etc.)",
     "streaming_stations":    "Streaming Stations",
+    "streaming_stations_hint": "Listen to internet radio. Add stations from the directory or paste a stream URL.",
     "provider":              "Provider",
     "emby":                  "Emby",
     "jellyfin":              "Jellyfin",
@@ -1381,7 +1407,9 @@
       "keep_awake":       "Screen Keep-Awake",
       "keep_awake_desc":  "Keep the screen on during workouts",
       "calorie_est":      "Show Calorie Estimate",
-      "calorie_est_desc": "Approximate kcal per workout (Mifflin-St Jeor BMR + MET). Needs height, weight, date of birth, and sex set in Profile. Resistance-training estimates are loose by ±25%, treated as an \"~est\" badge in the UI, not a hard number."
+      "calorie_est_desc": "Approximate kcal per workout (Mifflin-St Jeor BMR + MET). Needs height, weight, date of birth, and sex set in Profile. Resistance-training estimates are loose by ±25%, treated as an \"~est\" badge in the UI, not a hard number.",
+      "track_cardio":      "Track Cardio",
+      "track_cardio_desc": "Log cardio sessions (bike, run, row, etc.) from the Diary and see weekly minutes on Statistics. Off by default so pure lifters aren't cluttered. Manual entry only; device sync stays in NutriTrace."
     },
     "logging": {
       "autofill":              "Auto-Fill Last Weights",
@@ -1420,7 +1448,19 @@
       "tone_desc":         "Brief chime when the timer hits zero",
       "tone_style":        "Tone Style",
       "tone_style_desc":   "Tap a row to select, tap ▶ to preview",
-      "preview":           "Preview"
+      "preview":           "Preview",
+      "tones": {
+        "classic":         "Classic",
+        "classic_desc":    "880 Hz beeps, higher chirp at 0",
+        "bells":           "Bells",
+        "bells_desc":      "Soft musical chime, major-third finale",
+        "beeper":          "Beeper",
+        "beeper_desc":     "Sharp short square-wave beeps",
+        "gym":             "Gym",
+        "gym_desc":        "Low thud countdown, rising horn at 0",
+        "minimal":         "Minimal",
+        "minimal_desc":    "Single soft click on the 0 mark only"
+      }
     },
     "body_stats": {
       "toggle_desc":       "Toggle which stats appear in the diary body stats sheet",


### PR DESCRIPTION
Second pass in the spirit of #37, this time on the Settings section components themselves: Radio, NutriTrace federation, Diagnostics, About, Workout, and Users. 38 new keys under the sections each component already uses. English output is unchanged, and following the new CONTRIBUTING flow the PR only adds English, so Weblate can pick the keys up for the existing locales.

A few calls you may want to sanity-check:

- Two keys that already existed but weren't wired anywhere now do their job: `settings_diagnostics.github_issue` is the link text in the logs hint, and `settings.users.role_self_suffix` replaces the literal `(you)` badge. Both already carry Spanish and Italian translations, so they show up translated with no Weblate round trip.
- The rest-timer tone names and descriptions live as data in `restTones.js`. I left that file alone and mapped them to keys at the render site in SettingsWorkout, by tone id, with the raw string as fallback for any future preset. Same pattern as the BODY_STATS list a few lines below it.
- `Coach {name}` and the `(you)` badge interpolate instead of concatenating. The role shown in that badge is still the raw stored value (`admin`, `member`, `trainer`); translating those means mapping stored values to labels, and that felt like your call.
- `write:workouts` and the example server URL stay as literal `<code>` markup between translated fragments. They're identifiers, and a key would just invite a translator to touch them.

Left out on purpose so this stays one concern: the connection-status banner in Radio (Configured/Connected and friends), the internals of the Diagnostic Logs sheet, and a handful of literals that duplicate keys that already exist (`'Username required'` next to `settings.users.err_username_required`, for example). Those last ones are a different kind of fix and I didn't want to mix them in here.

Validation: `npm run i18n:check` passes, no duplicates and all code-referenced keys resolve; the 38 new keys report as missing for `es` and `it` the same way the existing `updates.*` ones do until Weblate catches up. Production build is clean.

The Catalog and Workout Import sections have the same kind of strings. I kept them out because you've been in those two files recently; they're ready as a small follow-up once that area settles.
