### PR TITLE
i18n: use existing keys for coach Programs tab and three settings spots

### DIFF
--- a/src/components/layout/CoachTabs.svelte
+++ b/src/components/layout/CoachTabs.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { _ } from 'svelte-i18n';
   import { currentUser } from '../../stores/auth.js';
   import { location, push } from 'svelte-spa-router';
 
@@ -10,7 +11,7 @@
   <div class="coach-tabs">
     <button class="tab" class:active={current === 'programs'} on:click={() => push('/programs')}>
       <span class="material-symbols-rounded icon">calendar_month</span>
-      <span>Programs</span>
+      <span>{$_('nav.programs')}</span>
     </button>
     <button class="tab" class:active={current === 'coaching'} on:click={() => push('/coaching')}>
       <span class="material-symbols-rounded icon">supervisor_account</span>

--- a/src/components/settings/SettingsFederation.svelte
+++ b/src/components/settings/SettingsFederation.svelte
@@ -166,12 +166,12 @@
               <input class="form-input-sm" style="flex:1;min-width:0;font-family:monospace" type="password"
                 bind:value={tokenDraft} placeholder="nt_pat_…" on:input={_invalidate} />
             {/if}
-            <button class="btn-icon-toggle" on:click={() => showToken = !showToken} title={showToken ? 'Hide' : 'Show'}>
+            <button class="btn-icon-toggle" on:click={() => showToken = !showToken} title={showToken ? $_('settings_trace.labels.hide') : $_('settings_trace.labels.show')}>
               <span class="material-symbols-rounded">{showToken ? 'visibility_off' : 'visibility'}</span>
             </button>
             <button class="btn btn-primary save-btn" on:click={save}
               disabled={testing || !urlDraft.trim() || !tokenDraft.trim()}>
-              {saved ? 'Saved' : (testing ? 'Testing…' : 'Save')}
+              {saved ? 'Saved' : (testing ? 'Testing…' : $_('common.save'))}
             </button>
           </div>
         </div>

--- a/src/components/settings/SettingsUserManagement.svelte
+++ b/src/components/settings/SettingsUserManagement.svelte
@@ -368,7 +368,7 @@
                     {#if u.id === $currentUser.id}
                       <span class="user-role-badge">{u.role} (you)</span>
                     {:else}
-                      <select class="form-select-xs" value={u.role} on:change={e => changeUserRole(u, e.target.value)} title="Role">
+                      <select class="form-select-xs" value={u.role} on:change={e => changeUserRole(u, e.target.value)} title={$_('settings.users.role')}>
                         <option value="member">{$_('settings.users.role_member_opt')}</option>
                         <option value="trainer">{$_('settings.users.role_trainer_opt')}</option>
                         <option value="admin">{$_('settings.users.role_admin_opt')}</option>
@@ -385,7 +385,7 @@
                   </div>
                 </div>
                 {#if u.id !== $currentUser.id}
-                  <button class="btn-icon-danger" on:click={() => resetUserPassword(u)} title="Reset Password" style="color:var(--text-3)">
+                  <button class="btn-icon-danger" on:click={() => resetUserPassword(u)} title={$_('settings.users.reset_password')} style="color:var(--text-3)">
                     <span class="material-symbols-rounded" style="font-size:20px">lock_reset</span>
                   </button>
                   <button class="btn-icon-danger" on:click={() => deleteUser(u.id)} title="Delete User">


### PR DESCRIPTION
Small companion to #66, different kind of fix: four spots were writing English literals whose keys already exist and already carry Spanish and Italian translations, so these labels were staying English in translated UIs for no reason.

- CoachTabs: the Programs tab now uses `nav.programs`, the same key BottomNav and the sidebar use for the same destination.
- SettingsFederation: the Save button uses `common.save`, and the token visibility toggle's tooltip reuses `settings_trace.labels.show` / `.hide`, the pair the Trace API key field already uses for the same gesture. The Saved and Testing… states have no exact keys today, so they stay as they are.
- SettingsUserManagement: the role select and the Reset Password button tooltips use `settings.users.role` and `settings.users.reset_password` from their own section.

No new keys and `en.json` untouched, so nothing new lands in Weblate's queue; the reused keys just start showing their existing translations. `i18n:check` and the production build pass.

There's a handful more of these (Diary, Profile, the catalog), but those files are in the middle of your wide-layout work, so I left them alone rather than chase your edits.
