### PR TITLE
i18n(statistics): route the desktop rail headings and comparison cards through $_()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Statistics desktop rails now flow through i18n** ([#83](https://github.com/TraceApps/lifttrace/pull/83)). The Summary / Progress / Trends group headings on the left metric rail, and the Range and "vs Prior" comparison cards on the right (Volume and Sessions labels included), were English literals in the template, so they stayed in English in every translated locale. They now resolve through `$_()` so Weblate can pick them up: nine new keys under `statistics.rail` (the labels, the "Prior window: n sessions" note as a one/other pair, and the two rails' `aria-label`s); Volume and Sessions reuse the labels the page already has.
+
 ## [1.3.0-dev01] - 2026-09-05
 
 ### Added

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1007,6 +1007,17 @@
       "y1":  "1Y",
       "all": "All"
     },
+    "rail": {
+      "summary":    "Summary",
+      "progress":   "Progress",
+      "trends":     "Trends",
+      "range":      "Range",
+      "vs_prior":   "vs Prior {range}",
+      "prior_window_one":   "Prior window: {n} session",
+      "prior_window_other": "Prior window: {n} sessions",
+      "nav_aria":   "Statistics sections",
+      "aside_aria": "Range + comparison"
+    },
     "categories": {
       "chest":     "Chest",
       "back":      "Back",

--- a/src/routes/Statistics.svelte
+++ b/src/routes/Statistics.svelte
@@ -47,12 +47,12 @@
     ];
     if ($cardioEnabled) trends.push(CARDIO_METRIC);
     return [
-      { title: 'Summary',  items: [{ id: 'overview', labelKey: 'statistics.tabs.overview', icon: 'dashboard' }] },
-      { title: 'Progress', items: [
+      { titleKey: 'statistics.rail.summary',  items: [{ id: 'overview', labelKey: 'statistics.tabs.overview', icon: 'dashboard' }] },
+      { titleKey: 'statistics.rail.progress', items: [
         { id: 'progress', labelKey: 'statistics.tabs.progress', icon: 'trending_up' },
         { id: 'records',  labelKey: 'statistics.tabs.records',  icon: 'emoji_events' },
       ]},
-      { title: 'Trends',   items: trends },
+      { titleKey: 'statistics.rail.trends',   items: trends },
     ];
   })();
 
@@ -576,10 +576,10 @@
   <!-- Left metric picker rail (desktop only via CSS). Replaces the
        horizontal .metric-bar chip scroller with a grouped, always-
        visible vertical menu that mirrors the Settings rail idiom. -->
-  <nav class="stats-metric-rail" aria-label="Statistics sections">
+  <nav class="stats-metric-rail" aria-label={$_('statistics.rail.nav_aria')}>
     {#each METRIC_GROUPS as group}
       <div class="mr-group">
-        <span class="mr-group-title">{group.title}</span>
+        <span class="mr-group-title">{$_(group.titleKey)}</span>
         {#each group.items as m}
           <button type="button"
                   class="mr-btn"
@@ -1184,11 +1184,11 @@
        here so it stays visible as the user scrolls through the
        metric's widgets; prior-period delta KPIs surface the existing
        periodDeltas computation that was buried in a tiny chip. -->
-  <aside class="stats-rail" aria-label="Range + comparison">
+  <aside class="stats-rail" aria-label={$_('statistics.rail.aside_aria')}>
     <div class="rail-card">
       <div class="rail-card-head">
         <span class="material-symbols-rounded">date_range</span>
-        <span class="rail-card-title">Range</span>
+        <span class="rail-card-title">{$_('statistics.rail.range')}</span>
       </div>
       <div class="rail-range-chips">
         {#each Object.keys(RANGES) as r}
@@ -1200,12 +1200,12 @@
       <div class="rail-card">
         <div class="rail-card-head">
           <span class="material-symbols-rounded">compare_arrows</span>
-          <span class="rail-card-title">vs Prior {$_(RANGE_LABEL_KEYS[range])}</span>
+          <span class="rail-card-title">{$_('statistics.rail.vs_prior', { values: { range: $_(RANGE_LABEL_KEYS[range]) } })}</span>
         </div>
         <div class="rail-delta-stats">
           {#if periodDeltas.volPct != null}
             <div class="rail-delta">
-              <span class="rail-delta-label">Volume</span>
+              <span class="rail-delta-label">{$_('statistics.tabs.volume')}</span>
               <span class="rail-delta-val"
                     class:up={periodDeltas.volPct > 0}
                     class:down={periodDeltas.volPct < 0}>
@@ -1215,7 +1215,7 @@
           {/if}
           {#if periodDeltas.cntPct != null}
             <div class="rail-delta">
-              <span class="rail-delta-label">Sessions</span>
+              <span class="rail-delta-label">{$_('statistics.sessions')}</span>
               <span class="rail-delta-val"
                     class:up={periodDeltas.cntPct > 0}
                     class:down={periodDeltas.cntPct < 0}>
@@ -1224,7 +1224,9 @@
             </div>
           {/if}
         </div>
-        <div class="rail-delta-note">Prior window: {periodDeltas.priorCount} {periodDeltas.priorCount === 1 ? 'session' : 'sessions'}</div>
+        <div class="rail-delta-note">{periodDeltas.priorCount === 1
+          ? $_('statistics.rail.prior_window_one',   { values: { n: periodDeltas.priorCount } })
+          : $_('statistics.rail.prior_window_other', { values: { n: periodDeltas.priorCount } })}</div>
       </div>
     {/if}
   </aside>


### PR DESCRIPTION
Thanks for turning #75 around so quickly. Another small one from using the app in Spanish, this time Statistics on desktop: the left rail's Summary / Progress / Trends group headings and the right rail's Range and "vs Prior" cards (with their Volume and Sessions labels) stay in English in every locale, because `Statistics.svelte` has them as plain literals (`METRIC_GROUPS` around line 50 and the `<aside class="stats-rail">` around line 1187) and never calls `$_()` for them. Both rails' `aria-label`s are literals too, and so is the "Prior window: n sessions" note under the deltas, plural handled inline.

This routes them through i18n. Nine new keys under `statistics.rail`: the labels, the prior-window note as a `_one` / `_other` pair (the same pattern `effective_sets` already uses on this page), and the two `aria-label`s. Volume and Sessions reuse `statistics.tabs.volume` and `statistics.sessions`, which the page already renders for the same things, so those two come out translated with no Weblate round-trip. "vs Prior {range}" takes the range chip label as a placeholder, which is what the template was concatenating anyway.

Only `en.json` changes, so es and it pick the new keys up through Weblate as usual. `i18n:check` and the build are green, and nothing moves visually in English.
