### PR TITLE
i18n(settings): the API Tokens intro's guide-link text was a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Settings → API Tokens: the intro's "the MCP setup guide" link text now flows through i18n** ([#84](https://github.com/TraceApps/lifttrace/pull/84)). It was a literal in the template, so translated locales rendered a mixed-language sentence ("Consulta the MCP setup guide." in Spanish). One new key, `settings_api_tokens.intro_guide_link`.
+
 ## [1.3.0-dev01] - 2026-09-05
 
 ### Added

--- a/src/components/settings/SettingsApiTokens.svelte
+++ b/src/components/settings/SettingsApiTokens.svelte
@@ -162,7 +162,7 @@
       <p class="sub-label" style="padding:0 0 6px">
         {$_('settings_api_tokens.intro_before')} <em>{$_('settings_api_tokens.intro_dev')}</em>){$_('settings_api_tokens.intro_middle')}
         <code>/api/mcp</code>. {$_('settings_api_tokens.intro_see')}
-        <a href="https://traceapps.github.io/docs/lifttrace/mcp/" target="_blank" rel="noopener">the MCP setup guide</a>.
+        <a href="https://traceapps.github.io/docs/lifttrace/mcp/" target="_blank" rel="noopener">{$_('settings_api_tokens.intro_guide_link')}</a>.
       </p>
 
       {#if justCreatedRaw}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -625,6 +625,7 @@
     "intro_dev": "or another MCP-aware agent",
     "intro_middle": " talk to this LiftTrace instance directly. Tokens are scoped to a specific set of capabilities and connect to",
     "intro_see": "See",
+    "intro_guide_link": "the MCP setup guide",
     "just_created": {
       "title": "Token created:",
       "warn": "Copy this now — it will not be shown again.",


### PR DESCRIPTION
Tiny one from the new API Tokens section, seen in Spanish: the intro sentence is split into i18n fragments, but the link text at the end ("the MCP setup guide", `SettingsApiTokens.svelte` line 165) is a literal, so translated locales get a mixed sentence: "Consulta the MCP setup guide." One new key, `settings_api_tokens.intro_guide_link`, and the rest is untouched. Since the section mirrors NutriTrace's, the same line is probably there too.

While in that file I noticed something next door, and I'm leaving it to you instead of guessing the wording: `_fmtRelative` (lines 147-157) computes `Date.now() - d` and checks `sec < 60` first, so any future date returns "just now". A token created with an expiry reads "expires just now" until the expiry actually passes, and "expires 3d ago" after that. Whether that should be "in 3d" or the plain date is your call, so no patch for it here.
